### PR TITLE
Update build to only include linux binary

### DIFF
--- a/.github/workflows/reelase.yml
+++ b/.github/workflows/reelase.yml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goos: [linux, darwin]
+        # keychain library is required for building darwin binary, however it's not available in ubuntu. Then we build only linux binary here.
+        goos: [linux]
         goarch: [amd64, arm64]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
keychain library is required for building darwin binary, however it's not available in ubuntu. Then we build only linux binary here