### PR TITLE
add(feat): Ignore error option

### DIFF
--- a/pkg/controller/cmd/cli.go
+++ b/pkg/controller/cmd/cli.go
@@ -39,6 +39,7 @@ func WithUsecase(usecase *usecase.Usecase) Option {
 func (x *Command) Run(args []string) error {
 	var appCfg model.Config
 	var dotEnvFiles cli.StringSlice
+	var ignoreErrors cli.StringSlice
 
 	app := &cli.App{
 		Name:    "zenv",
@@ -67,6 +68,13 @@ func (x *Command) Run(args []string) error {
 				Aliases:     []string{"o"},
 				Destination: (*string)(&appCfg.OverrideEnvFile),
 			},
+
+			&cli.StringSliceFlag{
+				Name:        "ignore-error",
+				Usage:       "ignore error [env_file_open]",
+				Aliases:     []string{"i"},
+				Destination: &ignoreErrors,
+			},
 		},
 		Commands: []*cli.Command{
 			x.cmdSecret(),
@@ -78,6 +86,14 @@ func (x *Command) Run(args []string) error {
 			appCfg.DotEnvFiles = make([]types.FilePath, len(dotEnvFiles.Value()))
 			for i, v := range dotEnvFiles.Value() {
 				appCfg.DotEnvFiles[i] = types.FilePath(v)
+			}
+
+			appCfg.IgnoreErrors = make(map[types.IgnoreError]struct{})
+			for _, v := range ignoreErrors.Value() {
+				if !types.IsIgnoreErrorCode(v) {
+					return fmt.Errorf("invalid ignore error: %s", v)
+				}
+				appCfg.IgnoreErrors[types.IgnoreError(v)] = struct{}{}
 			}
 
 			return nil

--- a/pkg/domain/model/config.go
+++ b/pkg/domain/model/config.go
@@ -1,8 +1,6 @@
 package model
 
 import (
-	"regexp"
-
 	"github.com/m-mizutani/zenv/pkg/domain/types"
 )
 
@@ -10,6 +8,5 @@ type Config struct {
 	KeychainNamespacePrefix types.NamespacePrefix
 	DotEnvFiles             []types.FilePath
 	OverrideEnvFile         types.FilePath
+	IgnoreErrors            map[types.IgnoreError]struct{}
 }
-
-var envVarNameRegex = regexp.MustCompile("^[a-zA-Z_][a-zA-Z0-9_]*$")

--- a/pkg/domain/types/errors.go
+++ b/pkg/domain/types/errors.go
@@ -13,3 +13,18 @@ var (
 	ErrGenerateRandom        = goerr.New("crypto/rand failed")
 	ErrInnerCommandFailed    = goerr.New("inner command failed")
 )
+
+type IgnoreError string
+
+const (
+	IgnoreEnvFileOpen IgnoreError = "env_file_open"
+)
+
+var ignoreErrorMap = map[IgnoreError]struct{}{
+	IgnoreEnvFileOpen: {},
+}
+
+func IsIgnoreErrorCode(s string) bool {
+	_, ok := ignoreErrorMap[IgnoreError(s)]
+	return ok
+}

--- a/pkg/usecase/exec_test.go
+++ b/pkg/usecase/exec_test.go
@@ -169,6 +169,25 @@ func TestReplacement(t *testing.T) {
 	})
 }
 
+func TestIgnoreError(t *testing.T) {
+	t.Run("ignore env file open error", func(t *testing.T) {
+		uc, mock := usecase.NewWithMock(usecase.WithConfig(&model.Config{
+			DotEnvFiles: []types.FilePath{".not_found_env"},
+			IgnoreErrors: map[types.IgnoreError]struct{}{
+				types.IgnoreEnvFileOpen: {},
+			},
+		}))
+		mock.ExecMock = func(vars []*model.EnvVar, args types.Arguments) error {
+			gt.Array(t, args).Equal([]types.Argument{"test"})
+			return nil
+		}
+
+		gt.NoError(t, uc.Exec(&model.ExecInput{
+			Args: types.Arguments{"test"},
+		}))
+	})
+}
+
 func TestOverride(t *testing.T) {
 	type testCase struct {
 		inputFiles []types.FilePath

--- a/pkg/usecase/usecase_test.go
+++ b/pkg/usecase/usecase_test.go
@@ -156,6 +156,7 @@ func TestAssign(t *testing.T) {
 		DotEnvFiles: []types.FilePath{".env"},
 	}))
 	mock.ReadFileMock = func(filename types.FilePath) ([]byte, error) {
+		gt.Value(t, filename).Equal(".env")
 		return []byte("BLUE=%ORANGE"), nil
 	}
 


### PR DESCRIPTION
`-i` option is now available. It can ignore specific error when executing zenv. Only `env_file_open` is supported.

```shell
zenv -i env_file_open -e .no_such_env ls
# no error
```