### PR TITLE
feat: redesign error output with typed domain errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/m-mizutani/zenv/v2/pkg/cli"
@@ -11,10 +10,8 @@ import (
 
 func main() {
 	if err := cli.Run(context.Background(), os.Args); err != nil {
-		exitCode := model.GetExitCode(err)
-		if !model.IsExecutorError(err) {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		}
-		os.Exit(exitCode)
+		// cli.Run is responsible for rendering err to stderr (structured,
+		// log-level aware). We just translate it into an exit code.
+		os.Exit(model.GetExitCode(err))
 	}
 }

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -239,6 +240,17 @@ func Run(ctx context.Context, args []string) error {
 	}
 
 	if err := uc.Run(ctx, commandArgs); err != nil {
+		// The executor's own non-zero exit already surfaces the child
+		// process's stderr to the user, so we do not double-print our own
+		// error block in that case.
+		if !model.IsExecutorError(err) {
+			verbose := level <= slog.LevelDebug
+			useColor := false
+			if f, ok := any(os.Stderr).(*os.File); ok {
+				useColor = term.IsTerminal(int(f.Fd()))
+			}
+			_, _ = fmt.Fprintln(os.Stderr, FormatError(err, verbose, useColor))
+		}
 		return err
 	}
 	return nil

--- a/pkg/cli/errfmt.go
+++ b/pkg/cli/errfmt.go
@@ -1,0 +1,353 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/m-mizutani/zenv/v2/pkg/model"
+)
+
+// ANSI color helpers. Active only when the caller passes color=true.
+const (
+	ansiReset  = "\x1b[0m"
+	ansiBold   = "\x1b[1m"
+	ansiRed    = "\x1b[31m"
+	ansiCyan   = "\x1b[36m"
+	ansiYellow = "\x1b[33m"
+	ansiDim    = "\x1b[2m"
+)
+
+// FormatError renders err for human consumption on a terminal.
+//
+//   - verbose=true attaches the underlying goerr trace (%+v) for debugging.
+//   - color=true emits ANSI escape sequences.
+//
+// The returned string does not have a trailing newline; callers may append
+// one when writing it out.
+func FormatError(err error, verbose, color bool) string {
+	if err == nil {
+		return ""
+	}
+	w := &errWriter{color: color}
+	w.writeHeader("Error", err)
+	formatErrorBody(w, err, 1)
+	if verbose {
+		w.writeRaw("\n")
+		w.writeDim("--- debug ---")
+		w.writeRaw("\n")
+		w.writeRaw(fmt.Sprintf("%+v", err))
+	}
+	return strings.TrimRight(w.b.String(), "\n")
+}
+
+// errWriter buffers formatted output and centralizes the color toggle.
+type errWriter struct {
+	b     strings.Builder
+	color bool
+}
+
+func (w *errWriter) writeRaw(s string) { w.b.WriteString(s) }
+func (w *errWriter) writeLine(indent int, s string) {
+	w.b.WriteString(strings.Repeat("  ", indent) + s + "\n")
+}
+func (w *errWriter) writeBoldRed(s string) string { return w.colored(ansiBold+ansiRed, s) }
+func (w *errWriter) writeCyan(s string) string    { return w.colored(ansiCyan, s) }
+func (w *errWriter) writeYellow(s string) string  { return w.colored(ansiYellow, s) }
+func (w *errWriter) writeDim(s string)            { w.b.WriteString(w.colored(ansiDim, s)) }
+func (w *errWriter) colored(code, s string) string {
+	if !w.color {
+		return s
+	}
+	return code + s + ansiReset
+}
+
+// writeHeader renders the top "Error: <summary>" line based on err's outermost
+// typed shape.
+func (w *errWriter) writeHeader(label string, err error) {
+	prefix := w.writeBoldRed(label + ":")
+	summary := topSummary(err)
+	w.b.WriteString(prefix + " " + summary + "\n")
+}
+
+// topSummary produces a one-line "what failed" for the outermost typed error.
+// It deliberately does not include details that belong on the indented body.
+func topSummary(err error) string {
+	var ve *model.VariableError
+	if errors.As(err, &ve) {
+		if ve.Key != "" {
+			return fmt.Sprintf("Failed to resolve variable %q", ve.Key)
+		}
+		return "Failed to resolve variable"
+	}
+	var cfe *model.ConfigFileError
+	if errors.As(err, &cfe) {
+		switch cfe.Reason {
+		case model.ReasonNotReadable:
+			return fmt.Sprintf("Cannot read %s config file", cfe.Format)
+		case model.ReasonParseError:
+			return fmt.Sprintf("Cannot parse %s config file", cfe.Format)
+		case model.ReasonInvalidSchema:
+			return fmt.Sprintf("Invalid %s configuration", cfe.Format)
+		}
+	}
+	return err.Error()
+}
+
+// formatErrorBody walks the cause chain and writes the indented "Source" /
+// "Cause" / "Hint" sections.
+func formatErrorBody(w *errWriter, err error, indent int) {
+	// Source line (file/profile) comes only from the outermost VariableError or
+	// ConfigFileError; deeper nesting does not repeat it.
+	if indent == 1 {
+		if src := sourceLine(err, w); src != "" {
+			w.writeLine(indent, src)
+		}
+	}
+
+	// Walk the cause chain, picking the next "interesting" typed node.
+	// Steps that produce no visible output (e.g. the outer VariableError whose
+	// summary already appeared in the header) must NOT consume the "first"
+	// flag, otherwise the first visible cause loses its "Cause:" label.
+	cur := err
+	depth := indent
+	first := true
+	for cur != nil {
+		line, ok, next := describeNode(cur, w, first)
+		if !ok {
+			break
+		}
+		if line != "" {
+			w.writeLine(depth, line)
+			depth++
+			first = false
+		}
+		if next == nil {
+			break
+		}
+		cur = next
+	}
+
+	// Hint
+	if h := hintFor(err, w); h != "" {
+		w.writeRaw("\n")
+		w.writeLine(indent, h)
+	}
+}
+
+// sourceLine formats the "Source:" header for the outermost error.
+func sourceLine(err error, w *errWriter) string {
+	var ve *model.VariableError
+	if errors.As(err, &ve) {
+		var parts []string
+		if ve.Path != "" {
+			parts = append(parts, ve.Path)
+		}
+		if ve.Profile != "" {
+			parts = append(parts, fmt.Sprintf("profile: %s", ve.Profile))
+		}
+		if len(parts) == 0 {
+			return ""
+		}
+		return w.writeCyan("Source: ") + strings.Join(parts, "  (") + closeParenIfProfile(ve.Profile)
+	}
+	var cfe *model.ConfigFileError
+	if errors.As(err, &cfe) {
+		if cfe.Path == "" {
+			return ""
+		}
+		return w.writeCyan("Source: ") + cfe.Path
+	}
+	return ""
+}
+
+func closeParenIfProfile(p string) string {
+	if p == "" {
+		return ""
+	}
+	return ")"
+}
+
+// describeNode formats the current error node and returns (line, more, nextCause).
+// When more=false, the traversal stops without printing line. When more=true and
+// line is non-empty, the caller prints line and descends into nextCause.
+func describeNode(err error, w *errWriter, isFirstCause bool) (string, bool, error) {
+	var ve *model.VariableError
+	if errors.As(err, &ve) && ve == err {
+		// The outer header already mentioned "Failed to resolve variable",
+		// so for the outer-most VariableError we just descend.
+		return "", true, ve.Cause
+	}
+
+	var ref *model.ReferenceError
+	if errors.As(err, &ref) && ref == err {
+		label := w.writeCyan(causeLabel(isFirstCause))
+		switch ref.Reason {
+		case model.RefNotFound:
+			line := label + fmt.Sprintf("Reference %q is not defined", ref.Ref)
+			if hint := suggestSimilar(ref.Ref, ref.Available); hint != "" {
+				line += "  (did you mean " + hint + "?)"
+			}
+			return line, true, ref.Cause
+		case model.RefCircular:
+			chain := strings.Join(ref.Chain, " -> ")
+			return label + fmt.Sprintf("Circular reference: %s", chain), true, ref.Cause
+		case model.RefResolveFailed:
+			return label + fmt.Sprintf("Reference %q could not be resolved", ref.Ref), true, ref.Cause
+		}
+	}
+
+	var re *model.ResolveError
+	if errors.As(err, &re) && re == err {
+		label := w.writeCyan(causeLabel(isFirstCause))
+		line := label + fmt.Sprintf("%s failed", capitalize(re.Op.String()))
+		if re.Target != "" {
+			line += ": " + re.Target
+		}
+		return line, true, re.Cause
+	}
+
+	var cmd *model.CommandExecError
+	if errors.As(err, &cmd) && cmd == err {
+		label := w.writeCyan(causeLabel(isFirstCause))
+		line := label + "Command failed: " + strings.Join(cmd.Command, " ")
+		if cmd.ExitCode != 0 {
+			line += fmt.Sprintf("  (exit %d)", cmd.ExitCode)
+		}
+		// stderr tail prints on additional indented lines
+		if cmd.Stderr != "" {
+			line += "\n" + indentStderr(cmd.Stderr, w)
+		}
+		// Do not descend into cmd.Cause. The Cause is usually a redundant
+		// restatement of the exit code (e.g. "exit status 1") and the
+		// exit code + stderr already convey what happened.
+		return line, true, nil
+	}
+
+	var cfe *model.ConfigFileError
+	if errors.As(err, &cfe) && cfe == err {
+		label := w.writeCyan(causeLabel(isFirstCause))
+		line := label + cfe.Error()
+		return line, true, cfe.Cause
+	}
+
+	// Fallback: leaf or unknown error
+	if isFirstCause {
+		// No structured cause-of-cause to dig into; just print Error().
+		return w.writeCyan("Cause: ") + err.Error(), true, nil
+	}
+	// Inner unknown leaf — just append its message
+	return err.Error(), true, nil
+}
+
+func causeLabel(first bool) string {
+	if first {
+		return "Cause:  "
+	}
+	return "└ "
+}
+
+func capitalize(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+// indentStderr inserts a prefix on each line of stderr output.
+func indentStderr(s string, w *errWriter) string {
+	prefix := strings.Repeat("  ", 3) + w.colored(ansiDim, "stderr> ")
+	var out strings.Builder
+	for i, line := range strings.Split(strings.TrimRight(s, "\n"), "\n") {
+		if i > 0 {
+			out.WriteString("\n")
+		}
+		out.WriteString(prefix + line)
+	}
+	return out.String()
+}
+
+// hintFor builds an actionable hint based on what's inside err.
+func hintFor(err error, w *errWriter) string {
+	var cmd *model.CommandExecError
+	if errors.As(err, &cmd) {
+		line := "Hint:  ensure `" + strings.Join(cmd.Command, " ") + "` runs successfully in your shell"
+		return w.writeYellow(line)
+	}
+	var ref *model.ReferenceError
+	if errors.As(err, &ref) && ref.Reason == model.RefNotFound {
+		line := fmt.Sprintf("Hint:  define %q in your config, .env, or system environment", ref.Ref)
+		return w.writeYellow(line)
+	}
+	if errors.As(err, &ref) && ref.Reason == model.RefCircular {
+		return w.writeYellow("Hint:  break the cycle by removing or restructuring one of the references")
+	}
+	var cfe *model.ConfigFileError
+	if errors.As(err, &cfe) && cfe.Reason == model.ReasonParseError {
+		return w.writeYellow("Hint:  fix the syntax error reported above and retry")
+	}
+	return ""
+}
+
+// suggestSimilar returns a quoted candidate from available that most closely
+// matches ref. The match is intentionally simple (substring or short edit
+// distance); good enough for typo hints. Returns "" if nothing useful.
+func suggestSimilar(ref string, available []string) string {
+	if ref == "" || len(available) == 0 {
+		return ""
+	}
+	type cand struct {
+		name string
+		dist int
+	}
+	var best []cand
+	for _, name := range available {
+		if name == "" {
+			continue
+		}
+		d := editDistance(strings.ToLower(ref), strings.ToLower(name))
+		// Heuristic: only suggest when within ceiling
+		if d <= 3 || strings.Contains(strings.ToLower(name), strings.ToLower(ref)) {
+			best = append(best, cand{name, d})
+		}
+	}
+	if len(best) == 0 {
+		return ""
+	}
+	sort.Slice(best, func(i, j int) bool { return best[i].dist < best[j].dist })
+	limit := min(3, len(best))
+	names := make([]string, 0, limit)
+	for _, c := range best[:limit] {
+		names = append(names, fmt.Sprintf("%q", c.name))
+	}
+	return strings.Join(names, ", ")
+}
+
+// editDistance is a small Levenshtein implementation used for typo hints.
+func editDistance(a, b string) int {
+	if a == b {
+		return 0
+	}
+	ar, br := []rune(a), []rune(b)
+	prev := make([]int, len(br)+1)
+	cur := make([]int, len(br)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(ar); i++ {
+		cur[0] = i
+		for j := 1; j <= len(br); j++ {
+			cost := 1
+			if ar[i-1] == br[j-1] {
+				cost = 0
+			}
+			del := prev[j] + 1
+			ins := cur[j-1] + 1
+			sub := prev[j-1] + cost
+			cur[j] = min(del, ins, sub)
+		}
+		prev, cur = cur, prev
+	}
+	return prev[len(br)]
+}

--- a/pkg/cli/errfmt.go
+++ b/pkg/cli/errfmt.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"unicode"
 
 	"github.com/m-mizutani/zenv/v2/pkg/model"
 )
@@ -140,17 +141,16 @@ func formatErrorBody(w *errWriter, err error, indent int) {
 func sourceLine(err error, w *errWriter) string {
 	var ve *model.VariableError
 	if errors.As(err, &ve) {
-		var parts []string
-		if ve.Path != "" {
-			parts = append(parts, ve.Path)
-		}
-		if ve.Profile != "" {
-			parts = append(parts, fmt.Sprintf("profile: %s", ve.Profile))
-		}
-		if len(parts) == 0 {
+		switch {
+		case ve.Path != "" && ve.Profile != "":
+			return w.writeCyan("Source: ") + ve.Path + "  (profile: " + ve.Profile + ")"
+		case ve.Path != "":
+			return w.writeCyan("Source: ") + ve.Path
+		case ve.Profile != "":
+			return w.writeCyan("Source: ") + "profile: " + ve.Profile
+		default:
 			return ""
 		}
-		return w.writeCyan("Source: ") + strings.Join(parts, "  (") + closeParenIfProfile(ve.Profile)
 	}
 	var cfe *model.ConfigFileError
 	if errors.As(err, &cfe) {
@@ -160,13 +160,6 @@ func sourceLine(err error, w *errWriter) string {
 		return w.writeCyan("Source: ") + cfe.Path
 	}
 	return ""
-}
-
-func closeParenIfProfile(p string) string {
-	if p == "" {
-		return ""
-	}
-	return ")"
 }
 
 // describeNode formats the current error node and returns (line, more, nextCause).
@@ -248,11 +241,13 @@ func causeLabel(first bool) string {
 	return "└ "
 }
 
+// capitalize uppercases the first rune of s. It walks runes (not bytes), so
+// multi-byte leading characters are handled correctly.
 func capitalize(s string) string {
-	if s == "" {
-		return s
+	for i, r := range s {
+		return string(unicode.ToUpper(r)) + s[i+len(string(r)):]
 	}
-	return strings.ToUpper(s[:1]) + s[1:]
+	return ""
 }
 
 // indentStderr inserts a prefix on each line of stderr output.

--- a/pkg/cli/errfmt_test.go
+++ b/pkg/cli/errfmt_test.go
@@ -1,0 +1,182 @@
+package cli_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/m-mizutani/goerr/v2"
+	"github.com/m-mizutani/gt"
+	"github.com/m-mizutani/zenv/v2/pkg/cli"
+	"github.com/m-mizutani/zenv/v2/pkg/model"
+)
+
+func TestFormatError_Nil(t *testing.T) {
+	gt.Equal(t, cli.FormatError(nil, false, false), "")
+}
+
+func TestFormatError_PlainError(t *testing.T) {
+	got := cli.FormatError(errors.New("boom"), false, false)
+	gt.S(t, got).
+		Contains("Error:").
+		Contains("boom").
+		NotContains("\x1b[")
+}
+
+// The realistic scenario from the spec: a HCL variable BACKSTREAM_HEADER
+// that references GOOGLE_ID_TOKEN, whose value is produced by a failing
+// gcloud command.
+func TestFormatError_RealisticChain(t *testing.T) {
+	cmdErr := &model.CommandExecError{
+		Command:  []string{"gcloud", "auth", "print-identity-token"},
+		ExitCode: 1,
+		Stderr:   "ERROR: (gcloud.auth.print-identity-token) Reauth required",
+		Cause:    errors.New("exit status 1"),
+	}
+	refErr := &model.ReferenceError{
+		Ref:    "GOOGLE_ID_TOKEN",
+		Reason: model.RefResolveFailed,
+		Cause:  cmdErr,
+	}
+	varErr := &model.VariableError{
+		Key:     "BACKSTREAM_HEADER",
+		Path:    ".env.hcl",
+		Profile: "dev",
+		Cause:   refErr,
+	}
+
+	got := cli.FormatError(varErr, false, false)
+
+	// Top line
+	gt.S(t, got).Contains(`Failed to resolve variable "BACKSTREAM_HEADER"`)
+	// Source line with path and profile
+	gt.S(t, got).Contains(".env.hcl").Contains("profile: dev")
+	// Reference and command surfaces
+	gt.S(t, got).Contains(`Reference "GOOGLE_ID_TOKEN" could not be resolved`)
+	gt.S(t, got).Contains("gcloud auth print-identity-token").Contains("exit 1")
+	// stderr tail surfaces (truncated rendering, but content visible)
+	gt.S(t, got).Contains("Reauth required")
+	// Hint surfaces
+	gt.S(t, got).Contains("Hint:").Contains("gcloud auth print-identity-token")
+	// No ANSI when color=false
+	gt.S(t, got).NotContains("\x1b[")
+	// No goerr internals
+	gt.S(t, got).NotContains("error.stacktrace").NotContains("Stacktrace:")
+}
+
+func TestFormatError_RefNotFound_WithSuggestion(t *testing.T) {
+	err := &model.VariableError{
+		Key: "FOO", Path: ".env.hcl",
+		Cause: &model.ReferenceError{
+			Ref:       "GOOGLE_ID_TOKN", // typo
+			Reason:    model.RefNotFound,
+			Available: []string{"GOOGLE_ID_TOKEN", "AWS_KEY", "OTHER"},
+		},
+	}
+	got := cli.FormatError(err, false, false)
+	gt.S(t, got).
+		Contains("not defined").
+		Contains("did you mean").
+		Contains(`"GOOGLE_ID_TOKEN"`)
+}
+
+func TestFormatError_RefCircular_PrintsChain(t *testing.T) {
+	err := &model.VariableError{
+		Key: "A",
+		Cause: &model.ReferenceError{
+			Ref:    "C",
+			Reason: model.RefCircular,
+			Chain:  []string{"A", "B", "C", "A"},
+		},
+	}
+	got := cli.FormatError(err, false, false)
+	gt.S(t, got).
+		Contains("Circular reference").
+		Contains("A -> B -> C -> A").
+		Contains("break the cycle")
+}
+
+func TestFormatError_ConfigFileParseError(t *testing.T) {
+	err := &model.ConfigFileError{
+		Path:   ".env.hcl",
+		Format: model.FormatHCL,
+		Reason: model.ReasonParseError,
+		Detail: "line 12: missing brace",
+	}
+	got := cli.FormatError(err, false, false)
+	gt.S(t, got).
+		Contains("Cannot parse hcl").
+		Contains(".env.hcl").
+		Contains("line 12").
+		Contains("Hint:")
+}
+
+func TestFormatError_VerboseAppendsGoerrTrace(t *testing.T) {
+	innerCause := goerr.New("inner failure")
+	err := &model.VariableError{
+		Key: "X", Path: ".env.hcl",
+		Cause: &model.ResolveError{
+			Op: model.OpReadFile, Target: "/no/such/file", Cause: innerCause,
+		},
+	}
+	verbose := cli.FormatError(err, true, false)
+	terse := cli.FormatError(err, false, false)
+
+	gt.S(t, verbose).Contains("--- debug ---")
+	gt.S(t, terse).NotContains("--- debug ---")
+
+	// Both should contain the friendly summary
+	gt.S(t, terse).Contains(`Failed to resolve variable "X"`)
+	gt.S(t, verbose).Contains(`Failed to resolve variable "X"`)
+}
+
+func TestFormatError_ColorEmitsAnsi(t *testing.T) {
+	err := &model.VariableError{Key: "X", Cause: errors.New("boom")}
+	got := cli.FormatError(err, false, true)
+	gt.S(t, got).Contains("\x1b[")
+}
+
+// Snapshot the realistic output for the BACKSTREAM_HEADER scenario, so the
+// formatting can be eyeballed via `go test -run TestFormatError_Snapshot -v`.
+func TestFormatError_Snapshot(t *testing.T) {
+	cmdErr := &model.CommandExecError{
+		Command:  []string{"gcloud", "auth", "print-identity-token"},
+		ExitCode: 1,
+		Stderr:   "ERROR: (gcloud.auth.print-identity-token) Reauth required.\nPlease run:\n  $ gcloud auth login",
+		Cause:    errors.New("exit status 1"),
+	}
+	refErr := &model.ReferenceError{
+		Ref:    "GOOGLE_ID_TOKEN",
+		Reason: model.RefResolveFailed,
+		Cause:  cmdErr,
+	}
+	varErr := &model.VariableError{
+		Key:     "BACKSTREAM_HEADER",
+		Path:    ".env.hcl",
+		Profile: "dev",
+		Cause:   refErr,
+	}
+
+	t.Log("\n--- terse / no color ---\n" + cli.FormatError(varErr, false, false))
+	t.Log("\n--- verbose / no color ---\n" + cli.FormatError(varErr, true, false))
+}
+
+func TestFormatError_TerseDoesNotLeakInternalWrapChain(t *testing.T) {
+	// Reproduce the historical "failed to load: failed to resolve: failed to
+	// build: failed to resolve reference: failed to execute command" leak.
+	cmdErr := &model.CommandExecError{Command: []string{"x"}, ExitCode: 1}
+	ref := &model.ReferenceError{Ref: "R", Reason: model.RefResolveFailed, Cause: cmdErr}
+	res := &model.ResolveError{Op: model.OpBuildContext, Cause: ref}
+	v := &model.VariableError{Key: "K", Path: "f", Cause: res}
+
+	got := cli.FormatError(v, false, false)
+	// The leak words from the historical message should NOT appear all at once.
+	leakWords := []string{"failed to load", "failed to resolve variable", "failed to build template context"}
+	hits := 0
+	for _, w := range leakWords {
+		if strings.Contains(got, w) {
+			hits++
+		}
+	}
+	gt.N(t, hits).Less(2)
+}

--- a/pkg/cli/errfmt_test.go
+++ b/pkg/cli/errfmt_test.go
@@ -64,6 +64,30 @@ func TestFormatError_RealisticChain(t *testing.T) {
 	gt.S(t, got).NotContains("error.stacktrace").NotContains("Stacktrace:")
 }
 
+func TestFormatError_Source_ProfileOnlyOrPathOnly(t *testing.T) {
+	t.Run("path only", func(t *testing.T) {
+		err := &model.VariableError{Key: "X", Path: ".env.hcl", Cause: errors.New("boom")}
+		got := cli.FormatError(err, false, false)
+		gt.S(t, got).Contains("Source: .env.hcl").NotContains("(")
+	})
+	t.Run("profile only", func(t *testing.T) {
+		err := &model.VariableError{Key: "X", Profile: "dev", Cause: errors.New("boom")}
+		got := cli.FormatError(err, false, false)
+		// Should not produce stray closing paren like "profile: dev)".
+		gt.S(t, got).Contains("Source: profile: dev").NotContains(")")
+	})
+	t.Run("both", func(t *testing.T) {
+		err := &model.VariableError{Key: "X", Path: ".env.hcl", Profile: "dev", Cause: errors.New("boom")}
+		got := cli.FormatError(err, false, false)
+		gt.S(t, got).Contains("Source: .env.hcl  (profile: dev)")
+	})
+	t.Run("neither", func(t *testing.T) {
+		err := &model.VariableError{Key: "X", Cause: errors.New("boom")}
+		got := cli.FormatError(err, false, false)
+		gt.S(t, got).NotContains("Source:")
+	})
+}
+
 func TestFormatError_RefNotFound_WithSuggestion(t *testing.T) {
 	err := &model.VariableError{
 		Key: "FOO", Path: ".env.hcl",

--- a/pkg/loader/dotenv_loader.go
+++ b/pkg/loader/dotenv_loader.go
@@ -3,12 +3,12 @@ package loader
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/m-mizutani/ctxlog"
-	"github.com/m-mizutani/goerr/v2"
 	"github.com/m-mizutani/zenv/v2/pkg/model"
 )
 
@@ -23,8 +23,12 @@ func NewDotEnvLoader(path string) LoadFunc {
 				logger.Debug(".env file not found", "path", path)
 				return nil, nil // File not found is acceptable
 			}
-			logger.Error("failed to open .env file", "path", path, "error", err)
-			return nil, goerr.Wrap(err, "failed to open .env file")
+			return nil, &model.ConfigFileError{
+				Path:   path,
+				Format: model.FormatDotEnv,
+				Reason: model.ReasonNotReadable,
+				Cause:  err,
+			}
 		}
 		defer file.Close()
 
@@ -44,10 +48,12 @@ func NewDotEnvLoader(path string) LoadFunc {
 			// Parse KEY=VALUE
 			parts := strings.SplitN(line, "=", 2)
 			if len(parts) != 2 {
-				return nil, goerr.New("invalid format in .env file",
-					goerr.V("line", lineNumber),
-					goerr.V("content", line),
-				)
+				return nil, &model.ConfigFileError{
+					Path:   path,
+					Format: model.FormatDotEnv,
+					Reason: model.ReasonParseError,
+					Detail: fmt.Sprintf("line %d: %q is not in KEY=VALUE format", lineNumber, line),
+				}
 			}
 
 			key := strings.TrimSpace(parts[0])
@@ -69,8 +75,12 @@ func NewDotEnvLoader(path string) LoadFunc {
 		}
 
 		if err := scanner.Err(); err != nil {
-			logger.Error("failed to read .env file", "path", path, "error", err)
-			return nil, goerr.Wrap(err, "failed to read .env file")
+			return nil, &model.ConfigFileError{
+				Path:   path,
+				Format: model.FormatDotEnv,
+				Reason: model.ReasonNotReadable,
+				Cause:  err,
+			}
 		}
 
 		logger.Debug("loaded .env file", "path", path, "variables", len(envVars))

--- a/pkg/loader/dotenv_loader_test.go
+++ b/pkg/loader/dotenv_loader_test.go
@@ -2,6 +2,7 @@ package loader_test
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 
@@ -72,7 +73,10 @@ VALID_KEY=valid_value`
 		_, err := loadFunc(context.Background())
 
 		gt.Error(t, err)
-		gt.S(t, err.Error()).Contains("invalid format")
+		var cfgErr *model.ConfigFileError
+		gt.True(t, errors.As(err, &cfgErr))
+		gt.Equal(t, cfgErr.Format, model.FormatDotEnv)
+		gt.Equal(t, cfgErr.Reason, model.ReasonParseError)
 	})
 
 	t.Run("Handle empty lines and comments", func(t *testing.T) {

--- a/pkg/loader/hcl_loader.go
+++ b/pkg/loader/hcl_loader.go
@@ -2,6 +2,7 @@ package loader
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -135,8 +136,9 @@ func loadHCLFile(ctx context.Context, path string) (model.YAMLConfig, error) {
 	if err != nil {
 		// parseHCLBody returns goerr-based schema errors; wrap them as
 		// ConfigFileError so the formatter can attach the file path.
-		// Pass through if already typed.
-		if _, ok := err.(*model.ConfigFileError); ok {
+		// Pass through if already typed (even when wrapped).
+		var cfe *model.ConfigFileError
+		if errors.As(err, &cfe) {
 			return nil, err
 		}
 		return nil, &model.ConfigFileError{

--- a/pkg/loader/hcl_loader.go
+++ b/pkg/loader/hcl_loader.go
@@ -2,6 +2,7 @@ package loader
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -50,15 +51,24 @@ func NewHCLLoaderWithProfile(path string, profile string, existingVars ...[]*mod
 			}
 
 			if err := effectiveValue.Validate(); err != nil {
-				logger.Error("invalid HCL configuration", "key", key, "error", err)
-				return nil, goerr.Wrap(err, "invalid configuration", goerr.V("key", key))
+				return nil, &model.ConfigFileError{
+					Path:   path,
+					Format: model.FormatHCL,
+					Reason: model.ReasonInvalidSchema,
+					Detail: fmt.Sprintf("variable %q: %v", key, err),
+					Cause:  err,
+				}
 			}
 
 			logger.Debug("resolving HCL variable", "key", key)
 			resolvedValue, err := resolver.resolveWithValue(key, effectiveValue)
 			if err != nil {
-				logger.Error("failed to resolve HCL variable", "key", key, "error", err)
-				return nil, goerr.Wrap(err, "failed to resolve variable", goerr.V("key", key))
+				return nil, &model.VariableError{
+					Key:     key,
+					Path:    path,
+					Profile: profile,
+					Cause:   err,
+				}
 			}
 
 			envVars = append(envVars, &model.EnvVar{
@@ -81,29 +91,63 @@ func loadHCLFile(ctx context.Context, path string) (model.YAMLConfig, error) {
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
-		return nil, goerr.Wrap(err, "failed to check HCL file", goerr.V("path", path))
+		return nil, &model.ConfigFileError{
+			Path:   path,
+			Format: model.FormatHCL,
+			Reason: model.ReasonNotReadable,
+			Cause:  err,
+		}
 	}
 
 	logger.Debug("loading HCL file", "path", path)
 	data, err := os.ReadFile(path) // #nosec G304 - file path is user provided and expected
 	if err != nil {
-		return nil, goerr.Wrap(err, "failed to read HCL file", goerr.V("path", path))
+		return nil, &model.ConfigFileError{
+			Path:   path,
+			Format: model.FormatHCL,
+			Reason: model.ReasonNotReadable,
+			Cause:  err,
+		}
 	}
 
 	parser := hclparse.NewParser()
 	file, diags := parser.ParseHCL(data, path)
 	if diags.HasErrors() {
-		return nil, goerr.New("failed to parse HCL file",
-			goerr.V("path", path),
-			goerr.V("diagnostics", diags.Error()))
+		return nil, &model.ConfigFileError{
+			Path:   path,
+			Format: model.FormatHCL,
+			Reason: model.ReasonParseError,
+			Detail: diags.Error(),
+		}
 	}
 
 	body, ok := file.Body.(*hclsyntax.Body)
 	if !ok {
-		return nil, goerr.New("unexpected HCL body type", goerr.V("path", path))
+		return nil, &model.ConfigFileError{
+			Path:   path,
+			Format: model.FormatHCL,
+			Reason: model.ReasonInvalidSchema,
+			Detail: "unexpected HCL body type",
+		}
 	}
 
-	return parseHCLBody(body)
+	cfg, err := parseHCLBody(body)
+	if err != nil {
+		// parseHCLBody returns goerr-based schema errors; wrap them as
+		// ConfigFileError so the formatter can attach the file path.
+		// Pass through if already typed.
+		if _, ok := err.(*model.ConfigFileError); ok {
+			return nil, err
+		}
+		return nil, &model.ConfigFileError{
+			Path:   path,
+			Format: model.FormatHCL,
+			Reason: model.ReasonInvalidSchema,
+			Detail: err.Error(),
+			Cause:  err,
+		}
+	}
+	return cfg, nil
 }
 
 // parseHCLBody converts the top-level body of an HCL file into a YAMLConfig.

--- a/pkg/loader/yaml_loader.go
+++ b/pkg/loader/yaml_loader.go
@@ -3,6 +3,7 @@ package loader
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -15,6 +16,10 @@ import (
 	"github.com/m-mizutani/zenv/v2/pkg/model"
 	"gopkg.in/yaml.v3"
 )
+
+// stderrLimit caps how much of a failed command's stderr we retain on
+// CommandExecError. The tail is kept so the most relevant message survives.
+const stderrLimit = 4096
 
 func NewYAMLLoader(path string, existingVars ...[]*model.EnvVar) LoadFunc {
 	return NewYAMLLoaderWithProfile(path, "", existingVars...)
@@ -58,16 +63,24 @@ func NewYAMLLoaderWithProfile(path string, profile string, existingVars ...[]*mo
 			}
 
 			if err := effectiveValue.Validate(); err != nil {
-				logger.Error("invalid YAML configuration", "key", key, "error", err)
-				return nil, goerr.Wrap(err, "invalid configuration", goerr.V("key", key))
+				return nil, &model.ConfigFileError{
+					Path:   path,
+					Format: model.FormatYAML,
+					Reason: model.ReasonInvalidSchema,
+					Detail: fmt.Sprintf("variable %q: %v", key, err),
+					Cause:  err,
+				}
 			}
 
 			logger.Debug("resolving YAML variable", "key", key)
 			resolvedValue, err := resolver.resolveWithValue(key, effectiveValue)
 			if err != nil {
-				logger.Error("failed to resolve YAML variable", "key", key, "error", err)
-				return nil, goerr.Wrap(err, "failed to resolve variable",
-					goerr.V("key", key))
+				return nil, &model.VariableError{
+					Key:     key,
+					Path:    path,
+					Profile: profile,
+					Cause:   err,
+				}
 			}
 
 			envVar := &model.EnvVar{
@@ -94,20 +107,34 @@ func loadAndMergeYAMLFiles(ctx context.Context, path string) (model.YAMLConfig, 
 			if os.IsNotExist(err) {
 				return nil, false, nil // File not found is acceptable
 			}
-			return nil, false, goerr.Wrap(err, "failed to check YAML file", goerr.V("path", filePath))
+			return nil, false, &model.ConfigFileError{
+				Path:   filePath,
+				Format: model.FormatYAML,
+				Reason: model.ReasonNotReadable,
+				Cause:  err,
+			}
 		}
 
 		logger.Debug("loading YAML file", "path", filePath)
 		data, err := os.ReadFile(filePath) // #nosec G304 - file path is user provided and expected
 		if err != nil {
-			logger.Error("failed to read YAML file", "path", filePath, "error", err)
-			return nil, false, goerr.Wrap(err, "failed to read YAML file", goerr.V("path", filePath))
+			return nil, false, &model.ConfigFileError{
+				Path:   filePath,
+				Format: model.FormatYAML,
+				Reason: model.ReasonNotReadable,
+				Cause:  err,
+			}
 		}
 
 		var config model.YAMLConfig
 		if err := yaml.Unmarshal(data, &config); err != nil {
-			logger.Error("failed to parse YAML file", "path", filePath, "error", err)
-			return nil, false, goerr.Wrap(err, "failed to parse YAML file", goerr.V("path", filePath))
+			return nil, false, &model.ConfigFileError{
+				Path:   filePath,
+				Format: model.FormatYAML,
+				Reason: model.ReasonParseError,
+				Detail: err.Error(),
+				Cause:  err,
+			}
 		}
 
 		return config, true, nil
@@ -159,7 +186,13 @@ func loadAndMergeYAMLFiles(ctx context.Context, path string) (model.YAMLConfig, 
 	logger.Debug("merging YAML files", "yaml_path", yamlPath, "yml_path", ymlPath)
 	merged, err := mergeYAMLConfigs(config1, config2)
 	if err != nil {
-		return nil, goerr.Wrap(err, "failed to merge YAML configurations")
+		return nil, &model.ConfigFileError{
+			Path:   yamlPath + " / " + ymlPath,
+			Format: model.FormatYAML,
+			Reason: model.ReasonInvalidSchema,
+			Detail: err.Error(),
+			Cause:  err,
+		}
 	}
 
 	logger.Debug("merged YAML files", "variables", len(merged))
@@ -295,12 +328,24 @@ func readYAMLFile(path string) (string, error) {
 
 func executeYAMLCommand(command []string) (string, error) {
 	if len(command) == 0 {
-		return "", goerr.New("command is empty")
+		return "", &model.CommandExecError{Command: command, Cause: goerr.New("command is empty")}
 	}
 	cmd := exec.Command(command[0], command[1:]...) // #nosec G204 - command is from user-provided YAML config, which is expected
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
 	output, err := cmd.Output()
 	if err != nil {
-		return "", err
+		exitCode := 0
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		}
+		return "", &model.CommandExecError{
+			Command:  command,
+			ExitCode: exitCode,
+			Stderr:   model.TruncateStderr(stderr.String(), stderrLimit),
+			Cause:    err,
+		}
 	}
 	return strings.TrimSpace(string(output)), nil
 }
@@ -312,6 +357,7 @@ type yamlUnifiedResolver struct {
 	baseDir      string // Base directory for resolving relative file paths
 	resolvedVars map[string]string
 	resolving    map[string]bool   // Track variables currently being resolved
+	stack        []string          // Resolution order, used to report circular chains
 	externalVars map[string]string // Variables from .env files, system environment, and other sources
 }
 
@@ -344,14 +390,25 @@ func newYAMLUnifiedResolverWithProfileAndVars(config model.YAMLConfig, profile s
 	}
 }
 
-// buildTemplateContext resolves all refs and builds a context map for template execution
+// buildTemplateContext resolves all refs and builds a context map for template execution.
+// Errors from inner resolution are wrapped as ReferenceError so the outer layer
+// knows which reference triggered the failure.
 func (r *yamlUnifiedResolver) buildTemplateContext(refs []string) (map[string]string, error) {
 	context := make(map[string]string)
 	for _, ref := range refs {
 		refValue, err := r.resolve(ref)
 		if err != nil {
-			return nil, goerr.Wrap(err, "failed to resolve reference",
-				goerr.V("ref", ref))
+			// If resolve already returned a typed ReferenceError (e.g. RefNotFound
+			// or RefCircular), propagate it as-is to preserve its semantics.
+			var refErr *model.ReferenceError
+			if errors.As(err, &refErr) && refErr.Ref == ref {
+				return nil, err
+			}
+			return nil, &model.ReferenceError{
+				Ref:    ref,
+				Reason: model.RefResolveFailed,
+				Cause:  err,
+			}
 		}
 		context[ref] = refValue
 	}
@@ -366,13 +423,22 @@ func (r *yamlUnifiedResolver) resolve(key string) (string, error) {
 
 	// Check for circular reference
 	if r.resolving[key] {
-		return "", goerr.New("circular reference detected",
-			goerr.V("key", key))
+		chain := append([]string{}, r.stack...)
+		chain = append(chain, key)
+		return "", &model.ReferenceError{
+			Ref:    key,
+			Reason: model.RefCircular,
+			Chain:  chain,
+		}
 	}
 
 	// Mark as currently resolving
 	r.resolving[key] = true
-	defer delete(r.resolving, key)
+	r.stack = append(r.stack, key)
+	defer func() {
+		delete(r.resolving, key)
+		r.stack = r.stack[:len(r.stack)-1]
+	}()
 
 	// Get the configuration for this key
 	config, exists := r.config[key]
@@ -383,8 +449,11 @@ func (r *yamlUnifiedResolver) resolve(key string) (string, error) {
 			return value, nil
 		}
 		// Not found anywhere - return error for missing variable
-		return "", goerr.New("variable not found",
-			goerr.V("key", key))
+		return "", &model.ReferenceError{
+			Ref:       key,
+			Reason:    model.RefNotFound,
+			Available: r.availableNames(),
+		}
 	}
 
 	// Get effective value considering profile
@@ -392,10 +461,27 @@ func (r *yamlUnifiedResolver) resolve(key string) (string, error) {
 	return r.resolveWithValue(key, effectiveValue)
 }
 
+// availableNames returns a sorted list of names the resolver could resolve.
+// Used to populate ReferenceError.Available for "not found" suggestions.
+func (r *yamlUnifiedResolver) availableNames() []string {
+	names := make([]string, 0, len(r.config)+len(r.externalVars))
+	for k := range r.config {
+		names = append(names, k)
+	}
+	for k := range r.externalVars {
+		names = append(names, k)
+	}
+	return names
+}
+
 func (r *yamlUnifiedResolver) resolveWithValue(key string, config *model.YAMLValue) (string, error) {
 	if config == nil {
-		return "", goerr.New("nil configuration for key",
-			goerr.V("key", key))
+		// Indicates a logic bug in the caller; surface it via VariableError so it
+		// still goes through the structured formatting path.
+		return "", &model.VariableError{
+			Key:   key,
+			Cause: goerr.New("nil configuration"),
+		}
 	}
 
 	// Resolve based on type
@@ -406,24 +492,30 @@ func (r *yamlUnifiedResolver) resolveWithValue(key string, config *model.YAMLVal
 	case config.Value != nil:
 		// If refs are present, treat value as a template
 		if len(config.Refs) > 0 {
-			// Build context for template
+			// Build context for template; ReferenceError-typed errors are passed
+			// through so the formatter can describe which ref failed.
 			context, err := r.buildTemplateContext(config.Refs)
 			if err != nil {
-				return "", goerr.Wrap(err, "failed to build template context")
+				return "", err
 			}
 
 			// Parse and execute template
 			tmpl, err := template.New("env").Parse(*config.Value)
 			if err != nil {
-				return "", goerr.Wrap(err, "failed to parse value template",
-					goerr.V("value", *config.Value))
+				return "", &model.ResolveError{
+					Op:     model.OpTemplate,
+					Target: *config.Value,
+					Cause:  err,
+				}
 			}
 
 			var buf bytes.Buffer
 			if err := tmpl.Execute(&buf, context); err != nil {
-				return "", goerr.Wrap(err, "failed to execute value template",
-					goerr.V("value", *config.Value),
-					goerr.V("key", key))
+				return "", &model.ResolveError{
+					Op:     model.OpTemplate,
+					Target: *config.Value,
+					Cause:  err,
+				}
 			}
 
 			resolvedValue = buf.String()
@@ -439,8 +531,11 @@ func (r *yamlUnifiedResolver) resolveWithValue(key string, config *model.YAMLVal
 		}
 		resolvedValue, err = readYAMLFile(filePath)
 		if err != nil {
-			return "", goerr.Wrap(err, "failed to read file",
-				goerr.V("file", *config.File))
+			return "", &model.ResolveError{
+				Op:     model.OpReadFile,
+				Target: *config.File,
+				Cause:  err,
+			}
 		}
 
 	case len(config.Command) > 0:
@@ -452,7 +547,7 @@ func (r *yamlUnifiedResolver) resolveWithValue(key string, config *model.YAMLVal
 			// Build context for template
 			context, err := r.buildTemplateContext(config.Refs)
 			if err != nil {
-				return "", goerr.Wrap(err, "failed to build command template context")
+				return "", err
 			}
 
 			// Apply template to each command element
@@ -461,32 +556,46 @@ func (r *yamlUnifiedResolver) resolveWithValue(key string, config *model.YAMLVal
 			for i, cmdElement := range config.Command {
 				parsedTmpl, err := tmpl.Parse(cmdElement)
 				if err != nil {
-					return "", goerr.Wrap(err, "failed to parse command template",
-						goerr.V("element", cmdElement))
+					return "", &model.ResolveError{
+						Op:     model.OpTemplate,
+						Target: cmdElement,
+						Cause:  err,
+					}
 				}
 
 				var buf bytes.Buffer
 				if err := parsedTmpl.Execute(&buf, context); err != nil {
-					return "", goerr.Wrap(err, "failed to execute command template",
-						goerr.V("element", cmdElement))
+					return "", &model.ResolveError{
+						Op:     model.OpTemplate,
+						Target: cmdElement,
+						Cause:  err,
+					}
 				}
 				resolvedCommand[i] = buf.String()
 			}
 			commandToExecute = resolvedCommand
 		}
 
+		// executeYAMLCommand already returns a CommandExecError on failure.
 		resolvedValue, err = executeYAMLCommand(commandToExecute)
 		if err != nil {
-			return "", goerr.Wrap(err, "failed to execute command",
-				goerr.V("command", commandToExecute))
+			return "", err
 		}
 
 	case config.Alias != nil:
-		// Recursively resolve the alias target
+		// Recursively resolve the alias target.
 		resolvedValue, err = r.resolve(*config.Alias)
 		if err != nil {
-			return "", goerr.Wrap(err, "failed to resolve alias",
-				goerr.V("alias", *config.Alias))
+			// If resolve already returned ReferenceError-typed, pass through.
+			var refErr *model.ReferenceError
+			if errors.As(err, &refErr) && refErr.Ref == *config.Alias {
+				return "", err
+			}
+			return "", &model.ReferenceError{
+				Ref:    *config.Alias,
+				Reason: model.RefResolveFailed,
+				Cause:  err,
+			}
 		}
 	}
 

--- a/pkg/loader/yaml_loader_test.go
+++ b/pkg/loader/yaml_loader_test.go
@@ -2,6 +2,7 @@ package loader_test
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -101,7 +102,10 @@ func TestYAMLLoader(t *testing.T) {
 		loadFunc := loader.NewYAMLLoader("testdata/invalid_syntax.yaml")
 		_, err := loadFunc(context.Background())
 		gt.Error(t, err)
-		gt.S(t, err.Error()).Contains("failed to parse YAML file")
+		var cfgErr *model.ConfigFileError
+		gt.True(t, errors.As(err, &cfgErr))
+		gt.Equal(t, cfgErr.Reason, model.ReasonParseError)
+		gt.Equal(t, cfgErr.Format, model.FormatYAML)
 	})
 
 	t.Run("Handle validation errors", func(t *testing.T) {
@@ -115,7 +119,9 @@ func TestYAMLLoader(t *testing.T) {
 		loadFunc := loader.NewYAMLLoader("testdata/missing_file.yaml")
 		_, err := loadFunc(context.Background())
 		gt.Error(t, err)
-		gt.S(t, err.Error()).Contains("failed to read file")
+		var resolveErr *model.ResolveError
+		gt.True(t, errors.As(err, &resolveErr))
+		gt.Equal(t, resolveErr.Op, model.OpReadFile)
 	})
 
 	t.Run("Handle command execution failure", func(t *testing.T) {
@@ -228,7 +234,9 @@ ALIAS_TO_EMPTY:
 		loadFunc := loader.NewYAMLLoader("testdata/alias_missing.yaml")
 		_, err := loadFunc(context.Background())
 		gt.Error(t, err)
-		gt.S(t, err.Error()).Contains("variable not found")
+		var refErr *model.ReferenceError
+		gt.True(t, errors.As(err, &refErr))
+		gt.Equal(t, refErr.Reason, model.RefNotFound)
 	})
 
 	t.Run("Handle circular alias reference", func(t *testing.T) {
@@ -384,7 +392,9 @@ VAR_NAME:
 		loadFunc := loader.NewYAMLLoader(tmpFile.Name())
 		_, err := loadFunc(context.Background())
 		gt.Error(t, err)
-		gt.S(t, err.Error()).Contains("failed to parse value template")
+		var resolveErr *model.ResolveError
+		gt.True(t, errors.As(err, &resolveErr))
+		gt.Equal(t, resolveErr.Op, model.OpTemplate)
 	})
 
 	t.Run("Template without refs field", func(t *testing.T) {
@@ -727,7 +737,9 @@ TEST_TEMPLATE:
 		// Load and resolve - should error
 		_, err := loader(context.Background())
 		gt.Error(t, err)
-		gt.S(t, err.Error()).Contains("variable not found")
+		var refErr *model.ReferenceError
+		gt.True(t, errors.As(err, &refErr))
+		gt.Equal(t, refErr.Reason, model.RefNotFound)
 	})
 
 	t.Run("Error on missing variable in alias", func(t *testing.T) {
@@ -746,7 +758,9 @@ TEST_ALIAS:
 		// Load and resolve - should error
 		_, err := loader(context.Background())
 		gt.Error(t, err)
-		gt.S(t, err.Error()).Contains("variable not found")
+		var refErr *model.ReferenceError
+		gt.True(t, errors.As(err, &refErr))
+		gt.Equal(t, refErr.Reason, model.RefNotFound)
 	})
 
 	t.Run("Empty string vs missing variable distinction", func(t *testing.T) {
@@ -790,7 +804,9 @@ TEST_MISSING:
 		// Load and resolve - should error
 		_, err = loader2(context.Background())
 		gt.Error(t, err)
-		gt.S(t, err.Error()).Contains("variable not found")
+		var refErr *model.ReferenceError
+		gt.True(t, errors.As(err, &refErr))
+		gt.Equal(t, refErr.Reason, model.RefNotFound)
 	})
 
 	t.Run("Load YAML file with simple format only", func(t *testing.T) {

--- a/pkg/model/errors.go
+++ b/pkg/model/errors.go
@@ -1,0 +1,263 @@
+package model
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ConfigFormat identifies the syntax of a configuration file.
+type ConfigFormat int
+
+const (
+	FormatYAML ConfigFormat = iota
+	FormatHCL
+	FormatDotEnv
+)
+
+func (f ConfigFormat) String() string {
+	switch f {
+	case FormatYAML:
+		return "yaml"
+	case FormatHCL:
+		return "hcl"
+	case FormatDotEnv:
+		return "dotenv"
+	default:
+		return "unknown"
+	}
+}
+
+// ConfigFileReason classifies why a configuration file failed.
+type ConfigFileReason int
+
+const (
+	// ReasonNotReadable indicates the file could not be opened or read.
+	ReasonNotReadable ConfigFileReason = iota
+	// ReasonParseError indicates a syntactic parse failure.
+	ReasonParseError
+	// ReasonInvalidSchema indicates a semantically invalid configuration
+	// (unknown attribute, mutually exclusive fields, duplicate names, ...).
+	ReasonInvalidSchema
+)
+
+func (r ConfigFileReason) String() string {
+	switch r {
+	case ReasonNotReadable:
+		return "not readable"
+	case ReasonParseError:
+		return "parse error"
+	case ReasonInvalidSchema:
+		return "invalid schema"
+	default:
+		return "unknown"
+	}
+}
+
+// ConfigFileError describes a failure related to loading or interpreting a
+// configuration file.
+type ConfigFileError struct {
+	Path   string
+	Format ConfigFormat
+	Reason ConfigFileReason
+	// Detail carries parser-provided context (line numbers, diagnostics, ...).
+	Detail string
+	Cause  error
+}
+
+func (e *ConfigFileError) Error() string {
+	var b strings.Builder
+	switch e.Reason {
+	case ReasonNotReadable:
+		b.WriteString("cannot read ")
+	case ReasonParseError:
+		b.WriteString("cannot parse ")
+	case ReasonInvalidSchema:
+		b.WriteString("invalid ")
+	default:
+		b.WriteString("error in ")
+	}
+	b.WriteString(e.Format.String())
+	if e.Path != "" {
+		b.WriteString(" file ")
+		b.WriteString(e.Path)
+	} else {
+		b.WriteString(" file")
+	}
+	if e.Detail != "" {
+		b.WriteString(": ")
+		b.WriteString(e.Detail)
+	}
+	return b.String()
+}
+
+func (e *ConfigFileError) Unwrap() error { return e.Cause }
+
+// VariableError attaches the surrounding processing context (which variable in
+// which file under which profile) to an underlying failure. It carries no
+// failure semantics of its own; the actual reason lives in Cause.
+type VariableError struct {
+	Key     string
+	Path    string
+	Profile string
+	Cause   error
+}
+
+func (e *VariableError) Error() string {
+	var b strings.Builder
+	b.WriteString("variable ")
+	if e.Key != "" {
+		fmt.Fprintf(&b, "%q ", e.Key)
+	}
+	b.WriteString("failed")
+	if e.Cause != nil {
+		fmt.Fprintf(&b, ": %v", e.Cause)
+	}
+	return b.String()
+}
+
+func (e *VariableError) Unwrap() error { return e.Cause }
+
+// ResolveOp classifies the kind of value-resolution operation that failed.
+type ResolveOp int
+
+const (
+	OpReadFile ResolveOp = iota
+	OpExecCommand
+	OpTemplate
+	OpAlias
+	OpBuildContext
+)
+
+func (o ResolveOp) String() string {
+	switch o {
+	case OpReadFile:
+		return "read file"
+	case OpExecCommand:
+		return "execute command"
+	case OpTemplate:
+		return "expand template"
+	case OpAlias:
+		return "resolve alias"
+	case OpBuildContext:
+		return "build template context"
+	default:
+		return "unknown"
+	}
+}
+
+// ResolveError describes a failure of a specific value-resolution step.
+type ResolveError struct {
+	Op ResolveOp
+	// Target is a short description of what the operation acted on
+	// (file path, command rendering, alias name, etc.).
+	Target string
+	Cause  error
+}
+
+func (e *ResolveError) Error() string {
+	var b strings.Builder
+	b.WriteString(e.Op.String())
+	if e.Target != "" {
+		fmt.Fprintf(&b, " %q", e.Target)
+	}
+	b.WriteString(" failed")
+	if e.Cause != nil {
+		fmt.Fprintf(&b, ": %v", e.Cause)
+	}
+	return b.String()
+}
+
+func (e *ResolveError) Unwrap() error { return e.Cause }
+
+// ReferenceReason classifies why a reference lookup failed.
+type ReferenceReason int
+
+const (
+	// RefNotFound indicates the referenced name has no definition.
+	RefNotFound ReferenceReason = iota
+	// RefCircular indicates a cycle was detected while resolving a reference.
+	RefCircular
+	// RefResolveFailed indicates the referenced variable exists but its own
+	// resolution failed.
+	RefResolveFailed
+)
+
+func (r ReferenceReason) String() string {
+	switch r {
+	case RefNotFound:
+		return "not found"
+	case RefCircular:
+		return "circular reference"
+	case RefResolveFailed:
+		return "resolution failed"
+	default:
+		return "unknown"
+	}
+}
+
+// ReferenceError describes a failed reference lookup.
+type ReferenceError struct {
+	Ref    string
+	Reason ReferenceReason
+	// Chain holds the offending cycle for RefCircular (ordered).
+	Chain []string
+	// Available holds candidate names for sugar-suggesting on RefNotFound.
+	Available []string
+	Cause     error
+}
+
+func (e *ReferenceError) Error() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "reference %q ", e.Ref)
+	switch e.Reason {
+	case RefNotFound:
+		b.WriteString("not found")
+	case RefCircular:
+		b.WriteString("forms a circular reference")
+		if len(e.Chain) > 0 {
+			fmt.Fprintf(&b, " (%s)", strings.Join(e.Chain, " -> "))
+		}
+	case RefResolveFailed:
+		b.WriteString("could not be resolved")
+		if e.Cause != nil {
+			fmt.Fprintf(&b, ": %v", e.Cause)
+		}
+	default:
+		b.WriteString("failed")
+	}
+	return b.String()
+}
+
+func (e *ReferenceError) Unwrap() error { return e.Cause }
+
+// CommandExecError describes a failure of an external command spawned to
+// produce a configuration value (not the final command zenv was asked to run).
+type CommandExecError struct {
+	Command  []string
+	ExitCode int
+	// Stderr holds the tail of the failed command's stderr output (may be empty).
+	Stderr string
+	Cause  error
+}
+
+func (e *CommandExecError) Error() string {
+	cmd := strings.Join(e.Command, " ")
+	if e.ExitCode != 0 {
+		return fmt.Sprintf("command %q exited with status %d", cmd, e.ExitCode)
+	}
+	if e.Cause != nil {
+		return fmt.Sprintf("command %q failed: %v", cmd, e.Cause)
+	}
+	return fmt.Sprintf("command %q failed", cmd)
+}
+
+func (e *CommandExecError) Unwrap() error { return e.Cause }
+
+// TruncateStderr returns the trailing portion of s, never exceeding limit
+// bytes. The result is what should be stored in CommandExecError.Stderr.
+func TruncateStderr(s string, limit int) string {
+	if limit <= 0 || len(s) <= limit {
+		return s
+	}
+	return s[len(s)-limit:]
+}

--- a/pkg/model/errors_test.go
+++ b/pkg/model/errors_test.go
@@ -1,0 +1,148 @@
+package model_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/m-mizutani/gt"
+	"github.com/m-mizutani/zenv/v2/pkg/model"
+)
+
+func TestConfigFileError(t *testing.T) {
+	t.Run("reports format and path", func(t *testing.T) {
+		err := &model.ConfigFileError{
+			Path:   ".env.hcl",
+			Format: model.FormatHCL,
+			Reason: model.ReasonParseError,
+			Detail: "line 12: missing brace",
+		}
+		gt.S(t, err.Error()).Contains("hcl").Contains(".env.hcl").Contains("line 12")
+	})
+
+	t.Run("unwraps cause", func(t *testing.T) {
+		cause := errors.New("permission denied")
+		err := &model.ConfigFileError{
+			Path:   ".env.yaml",
+			Format: model.FormatYAML,
+			Reason: model.ReasonNotReadable,
+			Cause:  cause,
+		}
+		gt.True(t, errors.Is(err, cause))
+	})
+}
+
+func TestVariableError(t *testing.T) {
+	t.Run("carries key in message", func(t *testing.T) {
+		err := &model.VariableError{
+			Key:   "API_KEY",
+			Path:  ".env.hcl",
+			Cause: errors.New("boom"),
+		}
+		gt.S(t, err.Error()).Contains("API_KEY").Contains("boom")
+	})
+
+	t.Run("can be extracted via errors.As", func(t *testing.T) {
+		inner := &model.VariableError{Key: "FOO"}
+		wrapped := &model.ConfigFileError{Cause: inner}
+		var got *model.VariableError
+		gt.True(t, errors.As(wrapped, &got))
+		gt.Equal(t, got.Key, "FOO")
+	})
+}
+
+func TestResolveError(t *testing.T) {
+	t.Run("reports op kind", func(t *testing.T) {
+		err := &model.ResolveError{
+			Op:     model.OpExecCommand,
+			Target: "gcloud auth print-identity-token",
+			Cause:  errors.New("exit status 1"),
+		}
+		gt.S(t, err.Error()).
+			Contains("execute command").
+			Contains("gcloud").
+			Contains("exit status 1")
+	})
+
+	t.Run("unwraps cause", func(t *testing.T) {
+		cause := errors.New("io error")
+		err := &model.ResolveError{Op: model.OpReadFile, Cause: cause}
+		gt.True(t, errors.Is(err, cause))
+	})
+}
+
+func TestReferenceError(t *testing.T) {
+	t.Run("not found", func(t *testing.T) {
+		err := &model.ReferenceError{Ref: "FOO", Reason: model.RefNotFound}
+		gt.S(t, err.Error()).Contains("FOO").Contains("not found")
+	})
+
+	t.Run("circular reports chain", func(t *testing.T) {
+		err := &model.ReferenceError{
+			Ref:    "A",
+			Reason: model.RefCircular,
+			Chain:  []string{"A", "B", "A"},
+		}
+		gt.S(t, err.Error()).Contains("A -> B -> A").Contains("circular")
+	})
+
+	t.Run("resolve failed unwraps cause", func(t *testing.T) {
+		cause := errors.New("inner")
+		err := &model.ReferenceError{Ref: "X", Reason: model.RefResolveFailed, Cause: cause}
+		gt.True(t, errors.Is(err, cause))
+	})
+}
+
+func TestCommandExecError(t *testing.T) {
+	t.Run("formats command and exit code", func(t *testing.T) {
+		err := &model.CommandExecError{
+			Command:  []string{"gcloud", "auth", "print-identity-token"},
+			ExitCode: 1,
+		}
+		gt.S(t, err.Error()).
+			Contains("gcloud auth print-identity-token").
+			Contains("status 1")
+	})
+
+	t.Run("unwraps cause", func(t *testing.T) {
+		cause := errors.New("exec failed")
+		err := &model.CommandExecError{Command: []string{"x"}, Cause: cause}
+		gt.True(t, errors.Is(err, cause))
+	})
+}
+
+func TestTruncateStderr(t *testing.T) {
+	t.Run("keeps short input intact", func(t *testing.T) {
+		gt.Equal(t, model.TruncateStderr("hello", 100), "hello")
+	})
+
+	t.Run("keeps tail when exceeding limit", func(t *testing.T) {
+		long := strings.Repeat("a", 50) + "END"
+		got := model.TruncateStderr(long, 5)
+		gt.Equal(t, len(got), 5)
+		gt.S(t, got).HasSuffix("aaEND")
+	})
+
+	t.Run("non-positive limit returns input unchanged", func(t *testing.T) {
+		gt.Equal(t, model.TruncateStderr("abc", 0), "abc")
+	})
+}
+
+func TestNestedChainTraversal(t *testing.T) {
+	cmd := &model.CommandExecError{
+		Command:  []string{"gcloud", "auth", "print-identity-token"},
+		ExitCode: 1,
+		Cause:    errors.New("exit status 1"),
+	}
+	inner := &model.ResolveError{Op: model.OpExecCommand, Target: "gcloud", Cause: cmd}
+	ref := &model.ReferenceError{Ref: "GOOGLE_ID_TOKEN", Reason: model.RefResolveFailed, Cause: inner}
+	outer := &model.VariableError{Key: "BACKSTREAM_HEADER", Path: ".env.hcl", Profile: "dev", Cause: ref}
+
+	var gotCmd *model.CommandExecError
+	gt.True(t, errors.As(outer, &gotCmd))
+	gt.Equal(t, gotCmd.ExitCode, 1)
+
+	var gotRef *model.ReferenceError
+	gt.True(t, errors.As(outer, &gotRef))
+	gt.Equal(t, gotRef.Ref, "GOOGLE_ID_TOKEN")
+}

--- a/pkg/usecase/run.go
+++ b/pkg/usecase/run.go
@@ -55,7 +55,10 @@ func (uc *UseCase) Run(ctx context.Context, args []string) error {
 	for _, loadFunc := range uc.Loaders {
 		envVars, err := loadFunc(ctx)
 		if err != nil {
-			return goerr.Wrap(err, "failed to load environment variables")
+			// Loaders already return typed errors (ConfigFileError /
+			// VariableError / ...); passing them through preserves the
+			// structure for the CLI's error formatter.
+			return err
 		}
 		allEnvVars = append(allEnvVars, envVars...)
 	}

--- a/pkg/usecase/run_test.go
+++ b/pkg/usecase/run_test.go
@@ -2,6 +2,7 @@ package usecase_test
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"strings"
@@ -205,7 +206,9 @@ func TestUseCase(t *testing.T) {
 		err := uc.Run(context.Background(), []string{"echo", "test"})
 
 		gt.Error(t, err)
-		gt.S(t, err.Error()).Contains("failed to load environment variables")
+		// usecase passes loader errors through unchanged so the CLI's
+		// errfmt can inspect the typed structure.
+		gt.True(t, errors.Is(err, os.ErrNotExist))
 	})
 
 	t.Run("Parse inline environment variables correctly", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Replaces the noisy `goerr.Wrap` chain + `logger.Error` double-output with structured, typed domain errors and a single render path at the CLI boundary.
- Introduces `pkg/model/errors.go` with `ConfigFileError` / `VariableError` / `ResolveError` / `ReferenceError` / `CommandExecError`. Each carries the context the user actually needs (key, path, profile, op, ref, command, exit code, stderr tail).
- Adds `pkg/cli/errfmt.go` (`FormatError(err, verbose, color)`) that dispatches by `errors.As` per type and prints a Source / Cause / Hint block. `--log-level debug` appends a `%+v` debug section. ANSI color only when stderr is a TTY.
- Removes the duplicated `Error:` line from `main.go`; rendering is centralized in `cli.Run`, which already knows the log level.

## Before / After

Before — internal wrap chain leaked verbatim:
```
09:31:31 ERROR failed to resolve HCL variable key="BACKSTREAM_HEADER"
  error.stacktrace=[ ... 8 frames ... ]
  error.cause.message="failed to resolve reference"
  error.cause.values.ref="GOOGLE_ID_TOKEN"
  ...
Error: failed to load environment variables: failed to resolve variable: failed to build template context: failed to resolve reference: failed to execute command: exit status 1
```

After — single structured block:
```
Error: Failed to resolve variable "BACKSTREAM_HEADER"
  Source: .env.hcl  (profile: dev)
  Cause:  Reference "GOOGLE_ID_TOKEN" could not be resolved
    └ Command failed: gcloud auth print-identity-token  (exit 1)
      stderr> ERROR: (gcloud.auth.print-identity-token) Reauth required.
      stderr> Please run:
      stderr>   $ gcloud auth login

  Hint:  ensure `gcloud auth print-identity-token` runs successfully in your shell
```

`--log-level debug` adds a `--- debug ---` section underneath with goerr's `%+v` trace for development.

## Notes

- `ReferenceError` carries `Available` (typo hint via Levenshtein) and `Chain` (cycle path) so the formatter can render actionable suggestions without the loader knowing about UI.
- `executeYAMLCommand` extracts the exit code from `*exec.ExitError` and truncates stderr (4 KB tail) into `CommandExecError` so the renderer has everything it needs without re-running the child.
- `pkg/usecase/run.go` no longer wraps loader errors — the typed structure already carries the context.
- Loader test assertions that previously matched substring messages are now `errors.As`-based.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `golangci-lint run ./...` (remaining errcheck warnings are pre-existing in test files, untouched here)
- [x] `gosec -quiet ./...` (sole remaining issue is the pre-existing `exec.CommandContext` in `pkg/executor`)
- [x] Snapshot test (`TestFormatError_Snapshot`) printing the realistic gcloud failure scenario in terse and verbose modes