### PR TITLE
fix(executor): show error when target command fails to launch

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -240,9 +240,14 @@ func Run(ctx context.Context, args []string) error {
 	}
 
 	if err := uc.Run(ctx, commandArgs); err != nil {
-		// The executor's own non-zero exit already surfaces the child
-		// process's stderr to the user, so we do not double-print our own
-		// error block in that case.
+		// ExecutorError = the target command actually ran and exited non-zero.
+		// Its own stderr is already on the user's terminal, so we must NOT
+		// print another error block on top of it.
+		//
+		// Every other error path (CommandLaunchError when the child never
+		// launched, config-load failures, variable-resolution failures, ...)
+		// has produced no user-facing output yet, so it goes through the
+		// FormatError pipeline.
 		if !model.IsExecutorError(err) {
 			verbose := level <= slog.LevelDebug
 			useColor := false

--- a/pkg/cli/errfmt.go
+++ b/pkg/cli/errfmt.go
@@ -75,6 +75,18 @@ func (w *errWriter) writeHeader(label string, err error) {
 // topSummary produces a one-line "what failed" for the outermost typed error.
 // It deliberately does not include details that belong on the indented body.
 func topSummary(err error) string {
+	var le *model.CommandLaunchError
+	if errors.As(err, &le) {
+		name := launchName(le)
+		switch le.Reason {
+		case model.LaunchNotFound:
+			return fmt.Sprintf("Command %q not found in PATH", name)
+		case model.LaunchPermissionDenied:
+			return fmt.Sprintf("Command %q is not executable", name)
+		default:
+			return fmt.Sprintf("Command %q failed to launch", name)
+		}
+	}
 	var ve *model.VariableError
 	if errors.As(err, &ve) {
 		if ve.Key != "" {
@@ -94,6 +106,14 @@ func topSummary(err error) string {
 		}
 	}
 	return err.Error()
+}
+
+// launchName returns the executable name component for display.
+func launchName(le *model.CommandLaunchError) string {
+	if len(le.Command) > 0 {
+		return le.Command[0]
+	}
+	return ""
 }
 
 // formatErrorBody walks the cause chain and writes the indented "Source" /
@@ -225,6 +245,18 @@ func describeNode(err error, w *errWriter, isFirstCause bool) (string, bool, err
 		return line, true, cfe.Cause
 	}
 
+	var le *model.CommandLaunchError
+	if errors.As(err, &le) && le == err {
+		// The summary header already says "Command \"x\" not found / not
+		// executable". The cause line carries the underlying OS error verbatim
+		// so the user can copy-paste it into a search.
+		if le.Cause == nil {
+			return "", true, nil
+		}
+		label := w.writeCyan(causeLabel(isFirstCause))
+		return label + le.Cause.Error(), true, nil
+	}
+
 	// Fallback: leaf or unknown error
 	if isFirstCause {
 		// No structured cause-of-cause to dig into; just print Error().
@@ -265,6 +297,21 @@ func indentStderr(s string, w *errWriter) string {
 
 // hintFor builds an actionable hint based on what's inside err.
 func hintFor(err error, w *errWriter) string {
+	var le *model.CommandLaunchError
+	if errors.As(err, &le) {
+		name := launchName(le)
+		switch le.Reason {
+		case model.LaunchNotFound:
+			line := fmt.Sprintf("Hint:  ensure %q is installed and visible from your shell PATH", name)
+			return w.writeYellow(line)
+		case model.LaunchPermissionDenied:
+			line := fmt.Sprintf("Hint:  check that %q has the executable bit set (e.g. chmod +x)", name)
+			return w.writeYellow(line)
+		default:
+			line := fmt.Sprintf("Hint:  verify that %q can be launched in your environment", name)
+			return w.writeYellow(line)
+		}
+	}
 	var cmd *model.CommandExecError
 	if errors.As(err, &cmd) {
 		line := "Hint:  ensure `" + strings.Join(cmd.Command, " ") + "` runs successfully in your shell"

--- a/pkg/cli/errfmt.go
+++ b/pkg/cli/errfmt.go
@@ -108,12 +108,14 @@ func topSummary(err error) string {
 	return err.Error()
 }
 
-// launchName returns the executable name component for display.
+// launchName returns the executable name component for display. It falls back
+// to a generic word when the command vector is empty or its first element is
+// an empty string, so the rendered message does not contain an empty `""`.
 func launchName(le *model.CommandLaunchError) string {
-	if len(le.Command) > 0 {
+	if len(le.Command) > 0 && le.Command[0] != "" {
 		return le.Command[0]
 	}
-	return ""
+	return "command"
 }
 
 // formatErrorBody walks the cause chain and writes the indented "Source" /

--- a/pkg/cli/errfmt_test.go
+++ b/pkg/cli/errfmt_test.go
@@ -237,6 +237,25 @@ func TestFormatError_CommandLaunchError(t *testing.T) {
 			Contains(`Command "foo" not found`).
 			NotContains("Cause:")
 	})
+
+	t.Run("renders generic name for empty command vector", func(t *testing.T) {
+		err := &model.CommandLaunchError{Reason: model.LaunchNotFound}
+		got := cli.FormatError(err, false, false)
+		gt.S(t, got).
+			Contains(`Command "command" not found`).
+			NotContains(`Command ""`)
+	})
+
+	t.Run("renders generic name when first element is empty string", func(t *testing.T) {
+		err := &model.CommandLaunchError{
+			Command: []string{""},
+			Reason:  model.LaunchPermissionDenied,
+		}
+		got := cli.FormatError(err, false, false)
+		gt.S(t, got).
+			Contains(`Command "command" is not executable`).
+			NotContains(`Command ""`)
+	})
 }
 
 // Snapshot the launch-error rendering so the formatting can be inspected via

--- a/pkg/cli/errfmt_test.go
+++ b/pkg/cli/errfmt_test.go
@@ -185,6 +185,82 @@ func TestFormatError_Snapshot(t *testing.T) {
 	t.Log("\n--- verbose / no color ---\n" + cli.FormatError(varErr, true, false))
 }
 
+func TestFormatError_CommandLaunchError(t *testing.T) {
+	t.Run("not found surfaces summary, cause and hint", func(t *testing.T) {
+		err := &model.CommandLaunchError{
+			Command: []string{"nonexistent", "--flag"},
+			Reason:  model.LaunchNotFound,
+			Cause:   errors.New(`exec: "nonexistent": executable file not found in $PATH`),
+		}
+		got := cli.FormatError(err, false, false)
+		gt.S(t, got).
+			Contains(`Command "nonexistent" not found in PATH`).
+			Contains(`executable file not found`).
+			Contains("Hint:").
+			Contains("PATH").
+			NotContains("\x1b[")
+	})
+
+	t.Run("permission denied surfaces dedicated hint", func(t *testing.T) {
+		err := &model.CommandLaunchError{
+			Command: []string{"/tmp/foo"},
+			Reason:  model.LaunchPermissionDenied,
+			Cause:   errors.New("permission denied"),
+		}
+		got := cli.FormatError(err, false, false)
+		gt.S(t, got).
+			Contains(`Command "/tmp/foo" is not executable`).
+			Contains("permission denied").
+			Contains("chmod +x")
+	})
+
+	t.Run("other reason falls back to generic hint", func(t *testing.T) {
+		err := &model.CommandLaunchError{
+			Command: []string{"foo"},
+			Reason:  model.LaunchOther,
+			Cause:   errors.New("some other oddity"),
+		}
+		got := cli.FormatError(err, false, false)
+		gt.S(t, got).
+			Contains(`Command "foo" failed to launch`).
+			Contains("some other oddity").
+			Contains("Hint:")
+	})
+
+	t.Run("no extra Cause line when cause is nil", func(t *testing.T) {
+		err := &model.CommandLaunchError{
+			Command: []string{"foo"},
+			Reason:  model.LaunchNotFound,
+		}
+		got := cli.FormatError(err, false, false)
+		gt.S(t, got).
+			Contains(`Command "foo" not found`).
+			NotContains("Cause:")
+	})
+}
+
+// Snapshot the launch-error rendering so the formatting can be inspected via
+// `go test -run TestFormatError_LaunchSnapshot -v`.
+func TestFormatError_LaunchSnapshot(t *testing.T) {
+	t.Run("not found", func(t *testing.T) {
+		err := &model.CommandLaunchError{
+			Command: []string{"nonexistent", "--flag"},
+			Reason:  model.LaunchNotFound,
+			Cause:   errors.New(`exec: "nonexistent": executable file not found in $PATH`),
+		}
+		t.Log("\n" + cli.FormatError(err, false, false))
+	})
+
+	t.Run("permission denied", func(t *testing.T) {
+		err := &model.CommandLaunchError{
+			Command: []string{"/tmp/foo"},
+			Reason:  model.LaunchPermissionDenied,
+			Cause:   errors.New("fork/exec /tmp/foo: permission denied"),
+		}
+		t.Log("\n" + cli.FormatError(err, false, false))
+	})
+}
+
 func TestFormatError_TerseDoesNotLeakInternalWrapChain(t *testing.T) {
 	// Reproduce the historical "failed to load: failed to resolve: failed to
 	// build: failed to resolve reference: failed to execute command" leak.

--- a/pkg/executor/default_executor.go
+++ b/pkg/executor/default_executor.go
@@ -2,7 +2,9 @@ package executor
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"syscall"
@@ -56,19 +58,49 @@ func NewDefaultExecutor() ExecuteFunc {
 			_ = stderrRedactor.Flush()
 		}
 		if err != nil {
-			// Extract exit code
-			if exitError, ok := err.(*exec.ExitError); ok {
+			// Case 1: the child actually ran and exited non-zero. Its stderr
+			// is already on the user's terminal, so we wrap it as an
+			// ExecutorError and stay silent at the cli layer.
+			var exitError *exec.ExitError
+			if errors.As(err, &exitError) {
+				exitCode := 1
 				if status, ok := exitError.Sys().(syscall.WaitStatus); ok {
-					exitCode := status.ExitStatus()
-					logger.Debug("command exited with non-zero code", "cmd", cmd, "exit_code", exitCode)
-					return model.NewExecutorError(err, exitCode)
+					exitCode = status.ExitStatus()
 				}
+				logger.Debug("command exited with non-zero code", "cmd", cmd, "exit_code", exitCode)
+				return model.NewExecutorError(err, exitCode)
 			}
-			logger.Debug("failed to execute command", "cmd", cmd, "error", err)
-			return model.NewExecutorError(err, 1)
+
+			// Case 2: the child never ran. Classify why so the cli layer can
+			// emit a helpful error message (the child has produced no stderr
+			// of its own).
+			logger.Debug("failed to launch command", "cmd", cmd, "error", err)
+			return classifyLaunchError(cmd, args, err)
 		}
 
 		logger.Debug("command executed successfully", "cmd", cmd)
 		return nil
+	}
+}
+
+// classifyLaunchError converts an os/exec failure that occurred BEFORE the
+// child started into a typed CommandLaunchError so the cli layer can render
+// it. The classification looks at the error chain rather than parsing the
+// message string.
+func classifyLaunchError(cmd string, args []string, err error) error {
+	command := append([]string{cmd}, args...)
+
+	reason := model.LaunchOther
+	switch {
+	case errors.Is(err, exec.ErrNotFound), errors.Is(err, fs.ErrNotExist):
+		reason = model.LaunchNotFound
+	case errors.Is(err, fs.ErrPermission), errors.Is(err, syscall.ENOEXEC):
+		reason = model.LaunchPermissionDenied
+	}
+
+	return &model.CommandLaunchError{
+		Command: command,
+		Reason:  reason,
+		Cause:   err,
 	}
 }

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -2,8 +2,11 @@ package executor_test
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/m-mizutani/gt"
@@ -61,10 +64,43 @@ func TestDefaultExecutor(t *testing.T) {
 		execFunc := executor.NewDefaultExecutor()
 		envVars := []*model.EnvVar{}
 
-		err := execFunc(context.Background(), "nonexistentcommand123", []string{}, envVars)
+		err := execFunc(context.Background(), "nonexistentcommand123", []string{"a", "b"}, envVars)
 		gt.Error(t, err)
-		gt.Equal(t, model.GetExitCode(err), 1)
-		gt.True(t, model.IsExecutorError(err))
+
+		// The child never ran, so this must NOT be classified as an
+		// ExecutorError (which means "child ran and exited non-zero").
+		gt.False(t, model.IsExecutorError(err))
+
+		var launchErr *model.CommandLaunchError
+		gt.True(t, errors.As(err, &launchErr))
+		gt.Equal(t, launchErr.Reason, model.LaunchNotFound)
+		gt.Equal(t, launchErr.Command, []string{"nonexistentcommand123", "a", "b"})
+
+		// POSIX shell convention: command not found -> 127.
+		gt.Equal(t, model.GetExitCode(err), 127)
+	})
+
+	t.Run("Handle non-executable file as command", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("permission bits do not apply on windows")
+		}
+
+		dir := t.TempDir()
+		path := filepath.Join(dir, "not-executable")
+		gt.NoError(t, os.WriteFile(path, []byte("hello\n"), 0o644))
+
+		execFunc := executor.NewDefaultExecutor()
+		err := execFunc(context.Background(), path, []string{}, nil)
+		gt.Error(t, err)
+
+		gt.False(t, model.IsExecutorError(err))
+
+		var launchErr *model.CommandLaunchError
+		gt.True(t, errors.As(err, &launchErr))
+		gt.Equal(t, launchErr.Reason, model.LaunchPermissionDenied)
+
+		// POSIX shell convention: cannot execute -> 126.
+		gt.Equal(t, model.GetExitCode(err), 126)
 	})
 
 	t.Run("Execute command with empty arguments", func(t *testing.T) {

--- a/pkg/model/env.go
+++ b/pkg/model/env.go
@@ -22,9 +22,14 @@ const (
 	SourceHCL
 )
 
-// ExecutorError represents an error from command execution.
-// When the executed command exits with a non-zero code, its stderr output
-// is already visible to the user, so zenv should not print additional messages.
+// ExecutorError represents the case where the target command was successfully
+// launched but exited with a non-zero status code. The child process's stderr
+// has already been streamed to the user, so zenv must NOT print an additional
+// error block on top.
+//
+// Failures that prevent the child from ever running (executable not found,
+// permission denied, ...) are represented by CommandLaunchError instead, and
+// zenv is responsible for emitting a human-readable message in that case.
 type ExecutorError struct {
 	err      error
 	exitCode int
@@ -63,6 +68,11 @@ func GetExitCode(err error) int {
 	var execErr *ExecutorError
 	if errors.As(err, &execErr) {
 		return execErr.ExitCode()
+	}
+
+	var launchErr *CommandLaunchError
+	if errors.As(err, &launchErr) {
+		return launchErr.ExitCode()
 	}
 
 	return 1 // Default exit code for errors

--- a/pkg/model/env_test.go
+++ b/pkg/model/env_test.go
@@ -66,4 +66,37 @@ func TestGetExitCode(t *testing.T) {
 		err := errors.New("generic error")
 		gt.Equal(t, model.GetExitCode(err), 1)
 	})
+
+	t.Run("returns 127 for CommandLaunchError with LaunchNotFound", func(t *testing.T) {
+		err := &model.CommandLaunchError{
+			Command: []string{"foo"},
+			Reason:  model.LaunchNotFound,
+		}
+		gt.Equal(t, model.GetExitCode(err), 127)
+	})
+
+	t.Run("returns 126 for CommandLaunchError with LaunchPermissionDenied", func(t *testing.T) {
+		err := &model.CommandLaunchError{
+			Command: []string{"foo"},
+			Reason:  model.LaunchPermissionDenied,
+		}
+		gt.Equal(t, model.GetExitCode(err), 126)
+	})
+
+	t.Run("returns 1 for CommandLaunchError with LaunchOther", func(t *testing.T) {
+		err := &model.CommandLaunchError{
+			Command: []string{"foo"},
+			Reason:  model.LaunchOther,
+		}
+		gt.Equal(t, model.GetExitCode(err), 1)
+	})
+
+	t.Run("returns exit code through wrapped CommandLaunchError", func(t *testing.T) {
+		launchErr := &model.CommandLaunchError{
+			Command: []string{"foo"},
+			Reason:  model.LaunchNotFound,
+		}
+		wrapped := fmt.Errorf("outer: %w", launchErr)
+		gt.Equal(t, model.GetExitCode(wrapped), 127)
+	})
 }

--- a/pkg/model/errors.go
+++ b/pkg/model/errors.go
@@ -293,8 +293,10 @@ type CommandLaunchError struct {
 }
 
 func (e *CommandLaunchError) Error() string {
-	name := ""
-	if len(e.Command) > 0 {
+	// Fall back to a generic word so the message stays descriptive even when
+	// the command vector is empty or its first element is an empty string.
+	name := "command"
+	if len(e.Command) > 0 && e.Command[0] != "" {
 		name = e.Command[0]
 	}
 	switch e.Reason {

--- a/pkg/model/errors.go
+++ b/pkg/model/errors.go
@@ -253,6 +253,79 @@ func (e *CommandExecError) Error() string {
 
 func (e *CommandExecError) Unwrap() error { return e.Cause }
 
+// LaunchReason classifies why the target command (the one zenv was asked to
+// run) could not be launched.
+type LaunchReason int
+
+const (
+	// LaunchNotFound indicates the executable was not found in PATH.
+	LaunchNotFound LaunchReason = iota
+	// LaunchPermissionDenied indicates the executable was found but cannot be
+	// executed (e.g. missing executable bit, not a regular file).
+	LaunchPermissionDenied
+	// LaunchOther covers any other startup failure that prevented the child
+	// process from ever running.
+	LaunchOther
+)
+
+func (r LaunchReason) String() string {
+	switch r {
+	case LaunchNotFound:
+		return "not found"
+	case LaunchPermissionDenied:
+		return "permission denied"
+	case LaunchOther:
+		return "launch failed"
+	default:
+		return "unknown"
+	}
+}
+
+// CommandLaunchError describes a failure to start the target command that
+// zenv was asked to run. Because the child process never executed, its stderr
+// did not appear and zenv itself is responsible for reporting the failure.
+type CommandLaunchError struct {
+	// Command is the full command vector including arguments. The executable
+	// name is Command[0].
+	Command []string
+	Reason  LaunchReason
+	Cause   error
+}
+
+func (e *CommandLaunchError) Error() string {
+	name := ""
+	if len(e.Command) > 0 {
+		name = e.Command[0]
+	}
+	switch e.Reason {
+	case LaunchNotFound:
+		return fmt.Sprintf("command %q not found in PATH", name)
+	case LaunchPermissionDenied:
+		return fmt.Sprintf("command %q is not executable", name)
+	default:
+		if e.Cause != nil {
+			return fmt.Sprintf("command %q failed to launch: %v", name, e.Cause)
+		}
+		return fmt.Sprintf("command %q failed to launch", name)
+	}
+}
+
+func (e *CommandLaunchError) Unwrap() error { return e.Cause }
+
+// ExitCode returns the exit code that zenv should propagate when the target
+// command failed to launch. Values follow the POSIX shell convention used by
+// bash: 127 for not-found, 126 for permission/exec failures, 1 otherwise.
+func (e *CommandLaunchError) ExitCode() int {
+	switch e.Reason {
+	case LaunchNotFound:
+		return 127
+	case LaunchPermissionDenied:
+		return 126
+	default:
+		return 1
+	}
+}
+
 // TruncateStderr returns the trailing portion of s, never exceeding limit
 // bytes. The result is what should be stored in CommandExecError.Stderr.
 func TruncateStderr(s string, limit int) string {

--- a/pkg/model/errors_test.go
+++ b/pkg/model/errors_test.go
@@ -173,6 +173,23 @@ func TestCommandLaunchError(t *testing.T) {
 		gt.True(t, errors.As(wrapped, &got))
 		gt.Equal(t, got.Reason, model.LaunchNotFound)
 	})
+
+	t.Run("falls back to generic name when command vector is empty", func(t *testing.T) {
+		err := &model.CommandLaunchError{Reason: model.LaunchNotFound}
+		gt.S(t, err.Error()).
+			Contains(`"command"`).
+			NotContains(`""`)
+	})
+
+	t.Run("falls back to generic name when first element is empty string", func(t *testing.T) {
+		err := &model.CommandLaunchError{
+			Command: []string{"", "arg"},
+			Reason:  model.LaunchPermissionDenied,
+		}
+		gt.S(t, err.Error()).
+			Contains(`"command"`).
+			NotContains(`""`)
+	})
 }
 
 func TestTruncateStderr(t *testing.T) {

--- a/pkg/model/errors_test.go
+++ b/pkg/model/errors_test.go
@@ -111,6 +111,70 @@ func TestCommandExecError(t *testing.T) {
 	})
 }
 
+func TestCommandLaunchError(t *testing.T) {
+	t.Run("not-found message includes executable name", func(t *testing.T) {
+		err := &model.CommandLaunchError{
+			Command: []string{"nonexistent", "arg1"},
+			Reason:  model.LaunchNotFound,
+		}
+		gt.S(t, err.Error()).
+			Contains("nonexistent").
+			Contains("not found").
+			Contains("PATH")
+	})
+
+	t.Run("permission-denied message includes executable name", func(t *testing.T) {
+		err := &model.CommandLaunchError{
+			Command: []string{"/tmp/not-executable"},
+			Reason:  model.LaunchPermissionDenied,
+		}
+		gt.S(t, err.Error()).
+			Contains("/tmp/not-executable").
+			Contains("not executable")
+	})
+
+	t.Run("other reason includes underlying cause", func(t *testing.T) {
+		cause := errors.New("operation not permitted")
+		err := &model.CommandLaunchError{
+			Command: []string{"foo"},
+			Reason:  model.LaunchOther,
+			Cause:   cause,
+		}
+		gt.S(t, err.Error()).
+			Contains("foo").
+			Contains("operation not permitted")
+	})
+
+	t.Run("unwraps cause", func(t *testing.T) {
+		cause := errors.New("inner")
+		err := &model.CommandLaunchError{Command: []string{"x"}, Cause: cause}
+		gt.True(t, errors.Is(err, cause))
+	})
+
+	t.Run("exit code follows POSIX shell convention", func(t *testing.T) {
+		gt.Equal(t,
+			(&model.CommandLaunchError{Reason: model.LaunchNotFound}).ExitCode(),
+			127,
+		)
+		gt.Equal(t,
+			(&model.CommandLaunchError{Reason: model.LaunchPermissionDenied}).ExitCode(),
+			126,
+		)
+		gt.Equal(t,
+			(&model.CommandLaunchError{Reason: model.LaunchOther}).ExitCode(),
+			1,
+		)
+	})
+
+	t.Run("can be extracted via errors.As through a wrapper", func(t *testing.T) {
+		inner := &model.CommandLaunchError{Command: []string{"foo"}, Reason: model.LaunchNotFound}
+		wrapped := &model.ResolveError{Op: model.OpExecCommand, Cause: inner}
+		var got *model.CommandLaunchError
+		gt.True(t, errors.As(wrapped, &got))
+		gt.Equal(t, got.Reason, model.LaunchNotFound)
+	})
+}
+
 func TestTruncateStderr(t *testing.T) {
 	t.Run("keeps short input intact", func(t *testing.T) {
 		gt.Equal(t, model.TruncateStderr("hello", 100), "hello")


### PR DESCRIPTION
## Summary

- When `zenv <cmd>` could not launch the target command (executable not found, permission denied, ...), zenv printed nothing and silently exited with code 1. The user had no clue what went wrong.
- This change introduces a typed `CommandLaunchError`, distinguishes "child ran and exited non-zero" from "child never launched", and routes the latter through the existing `FormatError` pipeline so a clear message and a hint are printed to stderr.
- Exit codes now follow POSIX shell convention: `127` for not-found, `126` for non-executable, `1` for other launch failures. The "child ran and exited non-zero" path is unchanged — its stderr is still treated as the source of truth and zenv stays silent on top of it.

### Example output

```
Error: Command "nonexistent" not found in PATH
  Cause:  exec: "nonexistent": executable file not found in $PATH

  Hint:  ensure "nonexistent" is installed and visible from your shell PATH
```

```
Error: Command "/tmp/foo" is not executable
  Cause:  fork/exec /tmp/foo: permission denied

  Hint:  check that "/tmp/foo" has the executable bit set (e.g. chmod +x)
```

### Classification

- `*exec.ExitError` → `ExecutorError` (unchanged; child's stderr is the source of truth)
- `errors.Is(err, exec.ErrNotFound)` / `fs.ErrNotExist` → `CommandLaunchError{LaunchNotFound}` (exit 127)
- `errors.Is(err, fs.ErrPermission)` / `syscall.ENOEXEC` → `CommandLaunchError{LaunchPermissionDenied}` (exit 126)
- everything else → `CommandLaunchError{LaunchOther}` (exit 1)

## Test plan

- [x] `go test ./...` — all existing tests pass
- [x] `pkg/model`: `TestCommandLaunchError` covers `Error()` / `Unwrap()` / `ExitCode()` for every reason
- [x] `pkg/model`: `TestGetExitCode` covers the new error type via direct and wrapped paths
- [x] `pkg/executor`: non-existent-command test asserts `LaunchNotFound` + exit 127; new permission-denied test creates a `chmod 644` file and asserts `LaunchPermissionDenied` + exit 126 (skipped on Windows)
- [x] `pkg/cli`: `TestFormatError_CommandLaunchError` covers summary, cause line, hint per reason, and the cause-omitted case; `TestFormatError_LaunchSnapshot` provides eyeball-able output