### PR TITLE
feat: validate -c/-e/-p/-l strictly instead of silent fallback

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -584,3 +584,18 @@ For additional support, see:
 - [v1 Documentation](https://github.com/m-mizutani/zenv/blob/main/README.md) for v1 features
 - [v2 Documentation](../README.md) for v2 features  
 - [GitHub Issues](https://github.com/m-mizutani/zenv/issues) for bug reports and questions
+
+## v2 Strict CLI Validation
+
+Starting from this release, `zenv` no longer silently swallows explicit CLI input that points at something missing or invalid. The following situations now produce a clear error and a non-zero exit status:
+
+| Flag | What used to happen | What happens now |
+|------|---------------------|------------------|
+| `-e <path>` / `--env <path>` | Missing file was silently skipped | Errors out with `missing dotenv file <path>` |
+| `-c <path>` / `--config <path>` | Missing YAML/HCL file was silently skipped | Errors out with `missing yaml config file <path>` (or `hcl`) |
+| `-p <profile>` / `--profile <profile>` | Unknown profile silently fell back to the default values | Errors out with the list of profiles actually defined in the loaded configuration |
+| `-l <level>` / `--log-level <level>` | Unknown level silently fell back to `warn` | Errors out with the accepted level names |
+
+The tolerant default-discovery behavior is unchanged: when `-e` / `-c` are omitted, the absence of `.env`, `.env.yaml`, `.env.yml`, and `.env.hcl` is still ignored. Only explicit flag values are validated strictly.
+
+If you have scripts that intentionally pass an optional configuration path, drop the flag when the file is not present (or add an existence check in the wrapper script).

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -25,13 +25,25 @@ import (
 // at least one of the supplied configuration files. The check is silent when
 // the profile is found; otherwise it returns a *model.ProfileNotFoundError
 // describing what was searched and which alternatives exist.
-func checkProfileExists(ctx context.Context, profile string, paths []string) error {
+//
+// When mustExist is true (caller passed --config explicitly), a missing file
+// surfaces as the underlying *model.ConfigFileError so the user sees a
+// targeted "missing file" error rather than the indirect "profile not found".
+// Only paths that actually contributed configuration are recorded in
+// ProfileNotFoundError.Paths, which lets the hint system distinguish
+// "configuration loaded but profile not defined" from "nothing was loaded".
+func checkProfileExists(ctx context.Context, profile string, paths []string, mustExist bool) error {
 	combined := make(map[string]struct{})
+	var foundPaths []string
 	for _, p := range paths {
-		names, err := loader.CollectProfileNames(ctx, p)
+		names, err := loader.CollectProfileNames(ctx, p, mustExist)
 		if err != nil {
 			return err
 		}
+		if names == nil {
+			continue
+		}
+		foundPaths = append(foundPaths, p)
 		for name := range names {
 			combined[name] = struct{}{}
 		}
@@ -49,7 +61,7 @@ func checkProfileExists(ctx context.Context, profile string, paths []string) err
 	return &model.ProfileNotFoundError{
 		Profile:   profile,
 		Available: available,
-		Paths:     append([]string{}, paths...),
+		Paths:     foundPaths,
 	}
 }
 
@@ -243,7 +255,7 @@ func Run(ctx context.Context, args []string) error {
 	// this before running any loader so the user doesn't see partial work
 	// (e.g. a successful command resolution) for an obviously wrong flag.
 	if profile != "" {
-		if err := checkProfileExists(ctx, profile, configPaths); err != nil {
+		if err := checkProfileExists(ctx, profile, configPaths, configExplicit); err != nil {
 			return err
 		}
 	}

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/m-mizutani/clog"
@@ -20,13 +21,47 @@ import (
 	"golang.org/x/term"
 )
 
+// checkProfileExists verifies that the requested profile name is defined in
+// at least one of the supplied configuration files. The check is silent when
+// the profile is found; otherwise it returns a *model.ProfileNotFoundError
+// describing what was searched and which alternatives exist.
+func checkProfileExists(ctx context.Context, profile string, paths []string) error {
+	combined := make(map[string]struct{})
+	for _, p := range paths {
+		names, err := loader.CollectProfileNames(ctx, p)
+		if err != nil {
+			return err
+		}
+		for name := range names {
+			combined[name] = struct{}{}
+		}
+	}
+	if _, ok := combined[profile]; ok {
+		return nil
+	}
+
+	available := make([]string, 0, len(combined))
+	for name := range combined {
+		available = append(available, name)
+	}
+	sort.Strings(available)
+
+	return &model.ProfileNotFoundError{
+		Profile:   profile,
+		Available: available,
+		Paths:     append([]string{}, paths...),
+	}
+}
+
 // newConfigLoader picks the appropriate loader based on the file extension.
 // Files ending in .hcl use the HCL loader; everything else falls back to YAML.
-func newConfigLoader(path, profile string, existingVars []*model.EnvVar) loader.LoadFunc {
+// mustExist=true is set when the path comes from an explicit --config flag, so
+// the loader fails fast on a missing file; default-discovery paths pass false.
+func newConfigLoader(path, profile string, mustExist bool, existingVars []*model.EnvVar) loader.LoadFunc {
 	if strings.EqualFold(filepath.Ext(path), ".hcl") {
-		return loader.NewHCLLoaderWithProfile(path, profile, existingVars)
+		return loader.NewHCLLoaderWithProfile(path, profile, mustExist, existingVars)
 	}
-	return loader.NewYAMLLoaderWithProfile(path, profile, existingVars)
+	return loader.NewYAMLLoaderWithProfile(path, profile, mustExist, existingVars)
 }
 
 // Format represents the log output format
@@ -79,19 +114,32 @@ func NewLoggerWithFormat(level slog.Level, w io.Writer, format Format) *slog.Log
 	return slog.New(handler)
 }
 
-// ParseLogLevel parses a string log level to slog.Level
-func ParseLogLevel(level string) slog.Level {
+// allowedLogLevels lists the user-facing log level names accepted by
+// ParseLogLevel. Kept here so the error message and the parser stay in sync.
+var allowedLogLevels = []string{"debug", "info", "warn", "error"}
+
+// ParseLogLevel parses a string log level to slog.Level.
+//
+// Unknown values (including the empty string) are reported as
+// model.InvalidLogLevelError so the caller can surface a precise error to the
+// user instead of silently falling back to a default. The CLI parser supplies
+// "warn" as the default when --log-level is omitted, so empty input here means
+// the user explicitly passed an empty value, which is also invalid.
+func ParseLogLevel(level string) (slog.Level, error) {
 	switch level {
 	case "debug", "DEBUG":
-		return slog.LevelDebug
-	case "info", "INFO", "":
-		return slog.LevelInfo
+		return slog.LevelDebug, nil
+	case "info", "INFO":
+		return slog.LevelInfo, nil
 	case "warn", "warning", "WARN", "WARNING":
-		return slog.LevelWarn
+		return slog.LevelWarn, nil
 	case "error", "ERROR":
-		return slog.LevelError
+		return slog.LevelError, nil
 	default:
-		return slog.LevelWarn // Default to warn as specified
+		return 0, &model.InvalidLogLevelError{
+			Value:   level,
+			Allowed: allowedLogLevels,
+		}
 	}
 }
 
@@ -163,12 +211,42 @@ func Run(ctx context.Context, args []string) error {
 	enableTemplate := result.Options["template"].IsSet()
 	commandArgs := result.Args
 
-	// Create logger based on log-level flag
-	level := ParseLogLevel(logLevel)
+	// Create logger based on log-level flag. An invalid level is reported up
+	// the chain so the user sees the standard FormatError output, just like
+	// every other start-up failure.
+	level, err := ParseLogLevel(logLevel)
+	if err != nil {
+		return err
+	}
 	logger := NewLogger(level, os.Stderr)
 
 	// Set logger in context for propagation
 	ctx = ctxlog.With(ctx, logger)
+
+	// Resolve the configuration paths that should drive both the profile
+	// preflight and the actual loader chain.
+	var configPaths []string
+	configExplicit := len(configFiles) > 0
+	if configExplicit {
+		configPaths = configFiles
+	} else {
+		// Default path resolution: prefer .env.hcl if present (do not merge with YAML).
+		if hclPath := loader.FindDefaultHCLPath(); hclPath != "" {
+			configPaths = []string{hclPath}
+		} else {
+			configPaths = []string{loader.ResolveDefaultYAMLPath()}
+		}
+	}
+
+	// Pre-flight: when --profile is set, ensure the requested profile name is
+	// defined somewhere in the configuration files we are about to load. We do
+	// this before running any loader so the user doesn't see partial work
+	// (e.g. a successful command resolution) for an obviously wrong flag.
+	if profile != "" {
+		if err := checkProfileExists(ctx, profile, configPaths); err != nil {
+			return err
+		}
+	}
 
 	// Collect environment variables in order for YAML loader reference
 	var allExistingVars []*model.EnvVar
@@ -185,13 +263,14 @@ func Run(ctx context.Context, args []string) error {
 		}
 	}
 
-	// Load .env files once and collect their variables
+	// Load .env files once and collect their variables. Explicitly passed
+	// paths (-e/--env) must exist; the default .env probe stays tolerant.
 	var envLoaders []loader.LoadFunc
 	for _, envFile := range envFiles {
-		envLoaders = append(envLoaders, loader.NewDotEnvLoader(envFile))
+		envLoaders = append(envLoaders, loader.NewDotEnvLoader(envFile, true))
 	}
 	if len(envFiles) == 0 {
-		envLoaders = append(envLoaders, loader.NewDotEnvLoader(loader.ResolveDefaultDotEnvPath()))
+		envLoaders = append(envLoaders, loader.NewDotEnvLoader(loader.ResolveDefaultDotEnvPath(), false))
 	}
 
 	// Execute .env loaders once and collect results
@@ -199,7 +278,7 @@ func Run(ctx context.Context, args []string) error {
 	for _, loadFunc := range envLoaders {
 		envVars, err := loadFunc(ctx)
 		if err != nil {
-			return goerr.Wrap(err, "failed to load .env file")
+			return err
 		}
 		if envVars != nil {
 			loadedDotEnvVars = append(loadedDotEnvVars, envVars...)
@@ -207,18 +286,11 @@ func Run(ctx context.Context, args []string) error {
 	}
 	allExistingVars = append(allExistingVars, loadedDotEnvVars...)
 
-	// Now create config loaders (HCL or YAML, picked by extension) with profile and existing vars
+	// Build config loaders for the same paths we used in the preflight.
+	// Explicit --config paths must exist; default-discovery paths stay tolerant.
 	var configLoaders []loader.LoadFunc
-	for _, configFile := range configFiles {
-		configLoaders = append(configLoaders, newConfigLoader(configFile, profile, allExistingVars))
-	}
-	if len(configFiles) == 0 {
-		// Default path resolution: prefer .env.hcl if present (do not merge with YAML).
-		if hclPath := loader.FindDefaultHCLPath(); hclPath != "" {
-			configLoaders = append(configLoaders, loader.NewHCLLoaderWithProfile(hclPath, profile, allExistingVars))
-		} else {
-			configLoaders = append(configLoaders, loader.NewYAMLLoaderWithProfile(loader.ResolveDefaultYAMLPath(), profile, allExistingVars))
-		}
+	for _, configPath := range configPaths {
+		configLoaders = append(configLoaders, newConfigLoader(configPath, profile, configExplicit, allExistingVars))
 	}
 
 	// Combine all loaders for the usecase

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -2,12 +2,16 @@ package cli_test
 
 import (
 	"context"
+	"errors"
 	"io"
+	"log/slog"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/m-mizutani/gt"
 	"github.com/m-mizutani/zenv/v2/pkg/cli"
+	"github.com/m-mizutani/zenv/v2/pkg/model"
 )
 
 func TestCLI(t *testing.T) {
@@ -257,22 +261,149 @@ FROM_HCL:
 		gt.S(t, string(output)).NotContains("hcl_loses")
 	})
 
-	t.Run("Handle non-existent file gracefully", func(t *testing.T) {
-		// Capture stdout to prevent flooding test output
+	t.Run("Explicit -e with missing file errors out", func(t *testing.T) {
+		args := []string{"zenv", "-e", "/definitely/not/here.env"}
+		err := cli.Run(context.Background(), args)
+
+		gt.Error(t, err)
+		var cfgErr *model.ConfigFileError
+		gt.True(t, errors.As(err, &cfgErr))
+		gt.Equal(t, cfgErr.Format, model.FormatDotEnv)
+		gt.Equal(t, cfgErr.Reason, model.ReasonNotFound)
+	})
+
+	t.Run("Explicit -c with missing YAML file errors out", func(t *testing.T) {
+		args := []string{"zenv", "-c", "/definitely/not/here.yaml"}
+		err := cli.Run(context.Background(), args)
+
+		gt.Error(t, err)
+		var cfgErr *model.ConfigFileError
+		gt.True(t, errors.As(err, &cfgErr))
+		gt.Equal(t, cfgErr.Format, model.FormatYAML)
+		gt.Equal(t, cfgErr.Reason, model.ReasonNotFound)
+	})
+
+	t.Run("Explicit -c with missing HCL file errors out", func(t *testing.T) {
+		args := []string{"zenv", "-c", "/definitely/not/here.hcl"}
+		err := cli.Run(context.Background(), args)
+
+		gt.Error(t, err)
+		var cfgErr *model.ConfigFileError
+		gt.True(t, errors.As(err, &cfgErr))
+		gt.Equal(t, cfgErr.Format, model.FormatHCL)
+		gt.Equal(t, cfgErr.Reason, model.ReasonNotFound)
+	})
+
+	t.Run("Invalid log level value errors out", func(t *testing.T) {
+		args := []string{"zenv", "-l", "noisy"}
+		err := cli.Run(context.Background(), args)
+
+		gt.Error(t, err)
+		var lvlErr *model.InvalidLogLevelError
+		gt.True(t, errors.As(err, &lvlErr))
+		gt.Equal(t, lvlErr.Value, "noisy")
+	})
+
+	t.Run("Unknown profile errors out", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		yamlPath := filepath.Join(tmpDir, "config.yaml")
+		content := `API_URL:
+  value: "https://api.example.com"
+  profile:
+    dev:
+      value: "http://localhost"
+`
+		gt.NoError(t, os.WriteFile(yamlPath, []byte(content), 0600))
+
+		args := []string{"zenv", "-c", yamlPath, "-p", "prod"}
+		err := cli.Run(context.Background(), args)
+
+		gt.Error(t, err)
+		var pe *model.ProfileNotFoundError
+		gt.True(t, errors.As(err, &pe))
+		gt.Equal(t, pe.Profile, "prod")
+		gt.Equal(t, len(pe.Available), 1)
+		gt.Equal(t, pe.Available[0], "dev")
+	})
+
+	t.Run("Known profile succeeds preflight", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		yamlPath := filepath.Join(tmpDir, "config.yaml")
+		content := `API_URL:
+  value: "default"
+  profile:
+    dev:
+      value: "dev-url"
+`
+		gt.NoError(t, os.WriteFile(yamlPath, []byte(content), 0600))
+
 		r, w, _ := os.Pipe()
 		oldStdout := os.Stdout
 		os.Stdout = w
 
-		// This should not error as non-existent files return nil, nil
-		args := []string{"zenv", "-e", "non_existent.env"}
+		args := []string{"zenv", "-c", yamlPath, "-p", "dev"}
 		err := cli.Run(context.Background(), args)
 
-		// Restore stdout
 		w.Close()
 		os.Stdout = oldStdout
-		// Read and discard output
+		output := gt.R1(io.ReadAll(r)).NoError(t)
+
+		gt.NoError(t, err)
+		gt.S(t, string(output)).Contains("API_URL=dev-url")
+	})
+
+	t.Run("Default .env probe still tolerates absence", func(t *testing.T) {
+		// In a temp directory with no .env, .env.yaml, .env.hcl, running zenv
+		// with no flags must NOT fail just because nothing was discovered.
+		tmpDir := t.TempDir()
+		oldWd := gt.R1(os.Getwd()).NoError(t)
+		gt.NoError(t, os.Chdir(tmpDir))
+		defer func() { _ = os.Chdir(oldWd) }()
+
+		r, w, _ := os.Pipe()
+		oldStdout := os.Stdout
+		os.Stdout = w
+
+		args := []string{"zenv"}
+		err := cli.Run(context.Background(), args)
+
+		w.Close()
+		os.Stdout = oldStdout
 		gt.R1(io.ReadAll(r)).NoError(t)
 
 		gt.NoError(t, err)
+	})
+}
+
+func TestParseLogLevel(t *testing.T) {
+	t.Run("known values map to slog levels", func(t *testing.T) {
+		cases := map[string]slog.Level{
+			"debug":   slog.LevelDebug,
+			"DEBUG":   slog.LevelDebug,
+			"info":    slog.LevelInfo,
+			"warn":    slog.LevelWarn,
+			"warning": slog.LevelWarn,
+			"error":   slog.LevelError,
+		}
+		for in, want := range cases {
+			got, err := cli.ParseLogLevel(in)
+			gt.NoError(t, err)
+			gt.Equal(t, got, want)
+		}
+	})
+
+	t.Run("unknown value returns InvalidLogLevelError", func(t *testing.T) {
+		_, err := cli.ParseLogLevel("verbose")
+		gt.Error(t, err)
+		var lvlErr *model.InvalidLogLevelError
+		gt.True(t, errors.As(err, &lvlErr))
+		gt.Equal(t, lvlErr.Value, "verbose")
+	})
+
+	t.Run("empty string is rejected", func(t *testing.T) {
+		_, err := cli.ParseLogLevel("")
+		gt.Error(t, err)
+		var lvlErr *model.InvalidLogLevelError
+		gt.True(t, errors.As(err, &lvlErr))
 	})
 }

--- a/pkg/cli/errfmt.go
+++ b/pkg/cli/errfmt.go
@@ -103,7 +103,17 @@ func topSummary(err error) string {
 			return fmt.Sprintf("Cannot parse %s config file", cfe.Format)
 		case model.ReasonInvalidSchema:
 			return fmt.Sprintf("Invalid %s configuration", cfe.Format)
+		case model.ReasonNotFound:
+			return fmt.Sprintf("Missing %s config file", cfe.Format)
 		}
+	}
+	var pe *model.ProfileNotFoundError
+	if errors.As(err, &pe) {
+		return fmt.Sprintf("Profile %q is not defined", pe.Profile)
+	}
+	var le2 *model.InvalidLogLevelError
+	if errors.As(err, &le2) {
+		return fmt.Sprintf("Invalid log level %q", le2.Value)
 	}
 	return err.Error()
 }
@@ -180,6 +190,10 @@ func sourceLine(err error, w *errWriter) string {
 			return ""
 		}
 		return w.writeCyan("Source: ") + cfe.Path
+	}
+	var pe *model.ProfileNotFoundError
+	if errors.As(err, &pe) && len(pe.Paths) > 0 {
+		return w.writeCyan("Source: ") + strings.Join(pe.Paths, ", ")
 	}
 	return ""
 }
@@ -328,8 +342,28 @@ func hintFor(err error, w *errWriter) string {
 		return w.writeYellow("Hint:  break the cycle by removing or restructuring one of the references")
 	}
 	var cfe *model.ConfigFileError
-	if errors.As(err, &cfe) && cfe.Reason == model.ReasonParseError {
-		return w.writeYellow("Hint:  fix the syntax error reported above and retry")
+	if errors.As(err, &cfe) {
+		switch cfe.Reason {
+		case model.ReasonParseError:
+			return w.writeYellow("Hint:  fix the syntax error reported above and retry")
+		case model.ReasonNotFound:
+			return w.writeYellow(fmt.Sprintf("Hint:  create the file at %q or remove the flag that points to it", cfe.Path))
+		}
+	}
+	var pe *model.ProfileNotFoundError
+	if errors.As(err, &pe) {
+		switch {
+		case len(pe.Available) > 0:
+			return w.writeYellow("Hint:  pick one of the available profiles: " + strings.Join(pe.Available, ", "))
+		case len(pe.Paths) == 0:
+			return w.writeYellow("Hint:  no configuration file was loaded; create one or omit --profile")
+		default:
+			return w.writeYellow("Hint:  define a profile block in your configuration or omit --profile")
+		}
+	}
+	var ll *model.InvalidLogLevelError
+	if errors.As(err, &ll) && len(ll.Allowed) > 0 {
+		return w.writeYellow("Hint:  use one of " + strings.Join(ll.Allowed, ", "))
 	}
 	return ""
 }

--- a/pkg/cli/errfmt_test.go
+++ b/pkg/cli/errfmt_test.go
@@ -280,6 +280,53 @@ func TestFormatError_LaunchSnapshot(t *testing.T) {
 	})
 }
 
+func TestFormatError_ConfigFileNotFound(t *testing.T) {
+	err := &model.ConfigFileError{
+		Path:   "/etc/missing.yaml",
+		Format: model.FormatYAML,
+		Reason: model.ReasonNotFound,
+	}
+	got := cli.FormatError(err, false, false)
+	gt.S(t, got).
+		Contains("Missing yaml config file").
+		Contains("/etc/missing.yaml").
+		Contains("Hint:")
+}
+
+func TestFormatError_ProfileNotFound(t *testing.T) {
+	t.Run("with available alternatives", func(t *testing.T) {
+		err := &model.ProfileNotFoundError{
+			Profile:   "prod",
+			Available: []string{"dev", "staging"},
+			Paths:     []string{".env.yaml"},
+		}
+		got := cli.FormatError(err, false, false)
+		gt.S(t, got).
+			Contains(`Profile "prod" is not defined`).
+			Contains(".env.yaml").
+			Contains("dev, staging")
+	})
+
+	t.Run("with no configuration loaded", func(t *testing.T) {
+		err := &model.ProfileNotFoundError{Profile: "prod"}
+		got := cli.FormatError(err, false, false)
+		gt.S(t, got).
+			Contains(`Profile "prod" is not defined`).
+			Contains("no configuration file was loaded")
+	})
+}
+
+func TestFormatError_InvalidLogLevel(t *testing.T) {
+	err := &model.InvalidLogLevelError{
+		Value:   "foo",
+		Allowed: []string{"debug", "info", "warn", "error"},
+	}
+	got := cli.FormatError(err, false, false)
+	gt.S(t, got).
+		Contains(`Invalid log level "foo"`).
+		Contains("debug, info, warn, error")
+}
+
 func TestFormatError_TerseDoesNotLeakInternalWrapChain(t *testing.T) {
 	// Reproduce the historical "failed to load: failed to resolve: failed to
 	// build: failed to resolve reference: failed to execute command" leak.

--- a/pkg/loader/dotenv_loader.go
+++ b/pkg/loader/dotenv_loader.go
@@ -3,7 +3,9 @@ package loader
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,16 +14,27 @@ import (
 	"github.com/m-mizutani/zenv/v2/pkg/model"
 )
 
-func NewDotEnvLoader(path string) LoadFunc {
+// NewDotEnvLoader builds a loader for a single .env file. When mustExist is
+// true, a missing file is reported as an error; otherwise it is silently
+// skipped (used for the default .env path).
+func NewDotEnvLoader(path string, mustExist bool) LoadFunc {
 	return func(ctx context.Context) ([]*model.EnvVar, error) {
 		logger := ctxlog.From(ctx)
 		logger.Debug("loading .env file", "path", path)
 
 		file, err := os.Open(filepath.Clean(path))
 		if err != nil {
-			if os.IsNotExist(err) {
+			if errors.Is(err, fs.ErrNotExist) {
+				if mustExist {
+					return nil, &model.ConfigFileError{
+						Path:   path,
+						Format: model.FormatDotEnv,
+						Reason: model.ReasonNotFound,
+						Cause:  err,
+					}
+				}
 				logger.Debug(".env file not found", "path", path)
-				return nil, nil // File not found is acceptable
+				return nil, nil
 			}
 			return nil, &model.ConfigFileError{
 				Path:   path,

--- a/pkg/loader/dotenv_loader_test.go
+++ b/pkg/loader/dotenv_loader_test.go
@@ -30,7 +30,7 @@ KEY4=value with spaces`
 		tmpFile.Close()
 
 		// Test loader
-		loadFunc := loader.NewDotEnvLoader(tmpFile.Name())
+		loadFunc := loader.NewDotEnvLoader(tmpFile.Name(), false)
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		gt.Equal(t, len(envVars), 4)
@@ -51,10 +51,21 @@ KEY4=value with spaces`
 		}
 	})
 
-	t.Run("Handle non-existent file", func(t *testing.T) {
-		loadFunc := loader.NewDotEnvLoader("non_existent.env")
+	t.Run("Handle non-existent file when mustExist=false", func(t *testing.T) {
+		loadFunc := loader.NewDotEnvLoader("non_existent.env", false)
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 		gt.Nil(t, envVars)
+	})
+
+	t.Run("Error on non-existent file when mustExist=true", func(t *testing.T) {
+		loadFunc := loader.NewDotEnvLoader("non_existent.env", true)
+		_, err := loadFunc(context.Background())
+		gt.Error(t, err)
+		var cfgErr *model.ConfigFileError
+		gt.True(t, errors.As(err, &cfgErr))
+		gt.Equal(t, cfgErr.Format, model.FormatDotEnv)
+		gt.Equal(t, cfgErr.Reason, model.ReasonNotFound)
+		gt.Equal(t, cfgErr.Path, "non_existent.env")
 	})
 
 	t.Run("Handle invalid format", func(t *testing.T) {
@@ -69,7 +80,7 @@ VALID_KEY=valid_value`
 		tmpFile.Close()
 
 		// Test loader
-		loadFunc := loader.NewDotEnvLoader(tmpFile.Name())
+		loadFunc := loader.NewDotEnvLoader(tmpFile.Name(), false)
 		_, err := loadFunc(context.Background())
 
 		gt.Error(t, err)
@@ -97,7 +108,7 @@ KEY2=value2
 		tmpFile.Close()
 
 		// Test loader
-		loadFunc := loader.NewDotEnvLoader(tmpFile.Name())
+		loadFunc := loader.NewDotEnvLoader(tmpFile.Name(), false)
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		gt.Equal(t, len(envVars), 2)

--- a/pkg/loader/hcl_loader.go
+++ b/pkg/loader/hcl_loader.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -15,17 +16,20 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-// NewHCLLoader creates a loader for HCL configuration files.
-func NewHCLLoader(path string, existingVars ...[]*model.EnvVar) LoadFunc {
-	return NewHCLLoaderWithProfile(path, "", existingVars...)
+// NewHCLLoader creates a loader for HCL configuration files. When mustExist is
+// true, a missing file is reported as an error; otherwise it is silently
+// skipped (used for the default .env.hcl path).
+func NewHCLLoader(path string, mustExist bool, existingVars ...[]*model.EnvVar) LoadFunc {
+	return NewHCLLoaderWithProfile(path, "", mustExist, existingVars...)
 }
 
 // NewHCLLoaderWithProfile creates a profile-aware loader for HCL configuration files.
-func NewHCLLoaderWithProfile(path string, profile string, existingVars ...[]*model.EnvVar) LoadFunc {
+// See NewHCLLoader for the mustExist semantics.
+func NewHCLLoaderWithProfile(path string, profile string, mustExist bool, existingVars ...[]*model.EnvVar) LoadFunc {
 	return func(ctx context.Context) ([]*model.EnvVar, error) {
 		logger := ctxlog.From(ctx)
 
-		config, err := loadHCLFile(ctx, path)
+		config, err := loadHCLFile(ctx, path, mustExist)
 		if err != nil {
 			return nil, err
 		}
@@ -85,11 +89,19 @@ func NewHCLLoaderWithProfile(path string, profile string, existingVars ...[]*mod
 	}
 }
 
-func loadHCLFile(ctx context.Context, path string) (model.YAMLConfig, error) {
+func loadHCLFile(ctx context.Context, path string, mustExist bool) (model.YAMLConfig, error) {
 	logger := ctxlog.From(ctx)
 
 	if _, err := os.Stat(path); err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
+			if mustExist {
+				return nil, &model.ConfigFileError{
+					Path:   path,
+					Format: model.FormatHCL,
+					Reason: model.ReasonNotFound,
+					Cause:  err,
+				}
+			}
 			return nil, nil
 		}
 		return nil, &model.ConfigFileError{

--- a/pkg/loader/hcl_loader_test.go
+++ b/pkg/loader/hcl_loader_test.go
@@ -2,6 +2,7 @@ package loader_test
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,10 +12,21 @@ import (
 	"github.com/m-mizutani/zenv/v2/pkg/model"
 )
 
+// newHCLLoader / newHCLLoaderWithProfile are mustExist=false wrappers used in
+// existing test cases. Strict (mustExist=true) behavior is covered by
+// dedicated test cases that call the production constructors directly.
+func newHCLLoader(path string, existingVars ...[]*model.EnvVar) loader.LoadFunc {
+	return loader.NewHCLLoader(path, false, existingVars...)
+}
+
+func newHCLLoaderWithProfile(path, profile string, existingVars ...[]*model.EnvVar) loader.LoadFunc {
+	return loader.NewHCLLoaderWithProfile(path, profile, false, existingVars...)
+}
+
 func TestHCLLoaderBasic(t *testing.T) {
 	t.Setenv("ZENV_TEST_HOME", "/home/zenv-test")
 
-	loadFunc := loader.NewHCLLoader("testdata/basic.hcl")
+	loadFunc := newHCLLoader("testdata/basic.hcl")
 	envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 	got := envVarMap(envVars)
@@ -39,7 +51,7 @@ func TestHCLLoaderBasic(t *testing.T) {
 
 func TestHCLLoaderProfile(t *testing.T) {
 	t.Run("default profile (no flag)", func(t *testing.T) {
-		loadFunc := loader.NewHCLLoader("testdata/profile.hcl")
+		loadFunc := newHCLLoader("testdata/profile.hcl")
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 		got := envVarMap(envVars)
 
@@ -49,7 +61,7 @@ func TestHCLLoaderProfile(t *testing.T) {
 	})
 
 	t.Run("dev profile (scalar attribute and structured block)", func(t *testing.T) {
-		loadFunc := loader.NewHCLLoaderWithProfile("testdata/profile.hcl", "dev")
+		loadFunc := newHCLLoaderWithProfile("testdata/profile.hcl", "dev")
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 		got := envVarMap(envVars)
 
@@ -59,7 +71,7 @@ func TestHCLLoaderProfile(t *testing.T) {
 	})
 
 	t.Run("prod profile unsets DEBUG_MODE via null", func(t *testing.T) {
-		loadFunc := loader.NewHCLLoaderWithProfile("testdata/profile.hcl", "prod")
+		loadFunc := newHCLLoaderWithProfile("testdata/profile.hcl", "prod")
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 		got := envVarMap(envVars)
 
@@ -72,7 +84,7 @@ func TestHCLLoaderProfile(t *testing.T) {
 }
 
 func TestHCLLoaderTemplate(t *testing.T) {
-	loadFunc := loader.NewHCLLoader("testdata/template.hcl")
+	loadFunc := newHCLLoader("testdata/template.hcl")
 	envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 	got := envVarMap(envVars)
 
@@ -81,9 +93,21 @@ func TestHCLLoaderTemplate(t *testing.T) {
 }
 
 func TestHCLLoaderNonExistentFile(t *testing.T) {
-	loadFunc := loader.NewHCLLoader("testdata/does_not_exist.hcl")
-	envVars := gt.R1(loadFunc(context.Background())).NoError(t)
-	gt.Nil(t, envVars)
+	t.Run("mustExist=false silently skips", func(t *testing.T) {
+		loadFunc := newHCLLoader("testdata/does_not_exist.hcl")
+		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
+		gt.Nil(t, envVars)
+	})
+
+	t.Run("mustExist=true returns ReasonNotFound", func(t *testing.T) {
+		loadFunc := loader.NewHCLLoader("testdata/does_not_exist.hcl", true)
+		_, err := loadFunc(context.Background())
+		gt.Error(t, err)
+		var cfgErr *model.ConfigFileError
+		gt.True(t, errors.As(err, &cfgErr))
+		gt.Equal(t, cfgErr.Format, model.FormatHCL)
+		gt.Equal(t, cfgErr.Reason, model.ReasonNotFound)
+	})
 }
 
 func TestHCLLoaderSyntaxError(t *testing.T) {
@@ -91,7 +115,7 @@ func TestHCLLoaderSyntaxError(t *testing.T) {
 	path := filepath.Join(tmp, "broken.hcl")
 	gt.NoError(t, os.WriteFile(path, []byte("FOO = \n"), 0600))
 
-	loadFunc := loader.NewHCLLoader(path)
+	loadFunc := newHCLLoader(path)
 	_, err := loadFunc(context.Background())
 	gt.Error(t, err)
 }
@@ -107,7 +131,7 @@ FOO {
 `
 		gt.NoError(t, os.WriteFile(path, []byte(content), 0600))
 
-		loadFunc := loader.NewHCLLoader(path)
+		loadFunc := newHCLLoader(path)
 		_, err := loadFunc(context.Background())
 		gt.Error(t, err)
 	})
@@ -124,7 +148,7 @@ FOO {
 `
 		gt.NoError(t, os.WriteFile(path, []byte(content), 0600))
 
-		loadFunc := loader.NewHCLLoader(path)
+		loadFunc := newHCLLoader(path)
 		_, err := loadFunc(context.Background())
 		gt.Error(t, err)
 	})
@@ -140,7 +164,7 @@ func TestHCLLoaderConflictingValueTypes(t *testing.T) {
 `
 	gt.NoError(t, os.WriteFile(path, []byte(content), 0600))
 
-	loadFunc := loader.NewHCLLoader(path)
+	loadFunc := newHCLLoader(path)
 	_, err := loadFunc(context.Background())
 	gt.Error(t, err)
 }
@@ -155,7 +179,7 @@ func TestHCLLoaderUnknownAttribute(t *testing.T) {
 `
 	gt.NoError(t, os.WriteFile(path, []byte(content), 0600))
 
-	loadFunc := loader.NewHCLLoader(path)
+	loadFunc := newHCLLoader(path)
 	_, err := loadFunc(context.Background())
 	gt.Error(t, err)
 }
@@ -169,7 +193,7 @@ func TestHCLLoaderBlockWithLabelRejected(t *testing.T) {
 `
 	gt.NoError(t, os.WriteFile(path, []byte(content), 0600))
 
-	loadFunc := loader.NewHCLLoader(path)
+	loadFunc := newHCLLoader(path)
 	_, err := loadFunc(context.Background())
 	gt.Error(t, err)
 }
@@ -184,7 +208,7 @@ func TestHCLLoaderInvalidRefs(t *testing.T) {
 `
 	gt.NoError(t, os.WriteFile(path, []byte(content), 0600))
 
-	loadFunc := loader.NewHCLLoader(path)
+	loadFunc := newHCLLoader(path)
 	_, err := loadFunc(context.Background())
 	gt.Error(t, err)
 }

--- a/pkg/loader/profile.go
+++ b/pkg/loader/profile.go
@@ -14,26 +14,31 @@ import (
 // a user-supplied --profile flag actually maps to something.
 //
 // Behavior:
-//   - If the file does not exist, an empty set is returned with a nil error.
-//     The caller treats this as "this file contributed no profile names" and
-//     decides separately whether the overall preflight should fail.
+//   - When mustExist is true, a missing file is reported as
+//     *model.ConfigFileError (Reason = ReasonNotFound). Callers pass true for
+//     paths that came from an explicit --config flag so the profile preflight
+//     surfaces the file-absence error rather than masking it as
+//     "profile not found".
+//   - When mustExist is false, a missing file returns (nil, nil). The caller
+//     uses the nil result to learn that this path contributed nothing — both
+//     to the profile-name union and to the "searched paths" list shown in
+//     ProfileNotFoundError.
 //   - If the file exists but cannot be parsed or is schema-invalid, the
 //     underlying loader error is returned as-is (typically
 //     *model.ConfigFileError) so the user sees the same diagnostics as during
 //     the normal load.
 //   - Unknown extensions are routed to the YAML reader, matching the loader
 //     dispatcher in pkg/cli.
-func CollectProfileNames(ctx context.Context, path string) (map[string]struct{}, error) {
-	names := make(map[string]struct{})
-
-	cfg, err := loadConfigForProfileScan(ctx, path)
+func CollectProfileNames(ctx context.Context, path string, mustExist bool) (map[string]struct{}, error) {
+	cfg, err := loadConfigForProfileScan(ctx, path, mustExist)
 	if err != nil {
 		return nil, err
 	}
 	if cfg == nil {
-		return names, nil
+		return nil, nil
 	}
 
+	names := make(map[string]struct{})
 	for _, value := range cfg {
 		for profileName := range value.Profile {
 			names[profileName] = struct{}{}
@@ -43,12 +48,12 @@ func CollectProfileNames(ctx context.Context, path string) (map[string]struct{},
 }
 
 // loadConfigForProfileScan loads a YAMLConfig from disk without resolving any
-// variables. The configuration is only used to enumerate profile names.
-// mustExist is false: callers want a profile preflight to silently skip
-// missing files, not to double-report file-absence errors.
-func loadConfigForProfileScan(ctx context.Context, path string) (model.YAMLConfig, error) {
+// variables. The configuration is only used to enumerate profile names. The
+// mustExist flag is forwarded to the underlying loader so that explicit
+// --config paths fail loudly when the file is missing.
+func loadConfigForProfileScan(ctx context.Context, path string, mustExist bool) (model.YAMLConfig, error) {
 	if strings.EqualFold(filepath.Ext(path), ".hcl") {
-		return loadHCLFile(ctx, path, false)
+		return loadHCLFile(ctx, path, mustExist)
 	}
-	return loadAndMergeYAMLFiles(ctx, path, false)
+	return loadAndMergeYAMLFiles(ctx, path, mustExist)
 }

--- a/pkg/loader/profile.go
+++ b/pkg/loader/profile.go
@@ -1,0 +1,54 @@
+package loader
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+
+	"github.com/m-mizutani/zenv/v2/pkg/model"
+)
+
+// CollectProfileNames reads the configuration file at path (YAML or HCL based
+// on extension) and returns the set of profile names that are defined under
+// any of its variables. The result is used by the CLI layer to validate that
+// a user-supplied --profile flag actually maps to something.
+//
+// Behavior:
+//   - If the file does not exist, an empty set is returned with a nil error.
+//     The caller treats this as "this file contributed no profile names" and
+//     decides separately whether the overall preflight should fail.
+//   - If the file exists but cannot be parsed or is schema-invalid, the
+//     underlying loader error is returned as-is (typically
+//     *model.ConfigFileError) so the user sees the same diagnostics as during
+//     the normal load.
+//   - Unknown extensions are routed to the YAML reader, matching the loader
+//     dispatcher in pkg/cli.
+func CollectProfileNames(ctx context.Context, path string) (map[string]struct{}, error) {
+	names := make(map[string]struct{})
+
+	cfg, err := loadConfigForProfileScan(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	if cfg == nil {
+		return names, nil
+	}
+
+	for _, value := range cfg {
+		for profileName := range value.Profile {
+			names[profileName] = struct{}{}
+		}
+	}
+	return names, nil
+}
+
+// loadConfigForProfileScan loads a YAMLConfig from disk without resolving any
+// variables. The configuration is only used to enumerate profile names.
+// mustExist is false: callers want a profile preflight to silently skip
+// missing files, not to double-report file-absence errors.
+func loadConfigForProfileScan(ctx context.Context, path string) (model.YAMLConfig, error) {
+	if strings.EqualFold(filepath.Ext(path), ".hcl") {
+		return loadHCLFile(ctx, path, false)
+	}
+	return loadAndMergeYAMLFiles(ctx, path, false)
+}

--- a/pkg/loader/profile_test.go
+++ b/pkg/loader/profile_test.go
@@ -2,19 +2,21 @@ package loader_test
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/m-mizutani/gt"
 	"github.com/m-mizutani/zenv/v2/pkg/loader"
+	"github.com/m-mizutani/zenv/v2/pkg/model"
 )
 
 func TestCollectProfileNames(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("collects all profile names from YAML", func(t *testing.T) {
-		names := gt.R1(loader.CollectProfileNames(ctx, "testdata/profile_basic.yaml")).NoError(t)
+		names := gt.R1(loader.CollectProfileNames(ctx, "testdata/profile_basic.yaml", false)).NoError(t)
 		gt.Equal(t, len(names), 3)
 		for _, want := range []string{"dev", "staging", "prod"} {
 			if _, ok := names[want]; !ok {
@@ -24,7 +26,7 @@ func TestCollectProfileNames(t *testing.T) {
 	})
 
 	t.Run("collects all profile names from HCL", func(t *testing.T) {
-		names := gt.R1(loader.CollectProfileNames(ctx, "testdata/profile.hcl")).NoError(t)
+		names := gt.R1(loader.CollectProfileNames(ctx, "testdata/profile.hcl", false)).NoError(t)
 		gt.Equal(t, len(names), 3)
 		for _, want := range []string{"dev", "staging", "prod"} {
 			if _, ok := names[want]; !ok {
@@ -34,22 +36,40 @@ func TestCollectProfileNames(t *testing.T) {
 	})
 
 	t.Run("returns empty set for YAML file without any profile blocks", func(t *testing.T) {
-		names := gt.R1(loader.CollectProfileNames(ctx, "testdata/valid.yaml")).NoError(t)
+		names := gt.R1(loader.CollectProfileNames(ctx, "testdata/valid.yaml", false)).NoError(t)
 		gt.Equal(t, len(names), 0)
 	})
 
-	t.Run("returns empty set when YAML file is missing", func(t *testing.T) {
-		names := gt.R1(loader.CollectProfileNames(ctx, "testdata/does_not_exist.yaml")).NoError(t)
-		gt.Equal(t, len(names), 0)
+	t.Run("returns nil when YAML file is missing and mustExist=false", func(t *testing.T) {
+		names := gt.R1(loader.CollectProfileNames(ctx, "testdata/does_not_exist.yaml", false)).NoError(t)
+		gt.Nil(t, names)
 	})
 
-	t.Run("returns empty set when HCL file is missing", func(t *testing.T) {
-		names := gt.R1(loader.CollectProfileNames(ctx, "testdata/does_not_exist.hcl")).NoError(t)
-		gt.Equal(t, len(names), 0)
+	t.Run("returns nil when HCL file is missing and mustExist=false", func(t *testing.T) {
+		names := gt.R1(loader.CollectProfileNames(ctx, "testdata/does_not_exist.hcl", false)).NoError(t)
+		gt.Nil(t, names)
+	})
+
+	t.Run("returns ConfigFileError when YAML file is missing and mustExist=true", func(t *testing.T) {
+		_, err := loader.CollectProfileNames(ctx, "testdata/does_not_exist.yaml", true)
+		gt.Error(t, err)
+		var cfgErr *model.ConfigFileError
+		gt.True(t, errors.As(err, &cfgErr))
+		gt.Equal(t, cfgErr.Format, model.FormatYAML)
+		gt.Equal(t, cfgErr.Reason, model.ReasonNotFound)
+	})
+
+	t.Run("returns ConfigFileError when HCL file is missing and mustExist=true", func(t *testing.T) {
+		_, err := loader.CollectProfileNames(ctx, "testdata/does_not_exist.hcl", true)
+		gt.Error(t, err)
+		var cfgErr *model.ConfigFileError
+		gt.True(t, errors.As(err, &cfgErr))
+		gt.Equal(t, cfgErr.Format, model.FormatHCL)
+		gt.Equal(t, cfgErr.Reason, model.ReasonNotFound)
 	})
 
 	t.Run("propagates parse errors for malformed YAML", func(t *testing.T) {
-		_, err := loader.CollectProfileNames(ctx, "testdata/invalid_syntax.yaml")
+		_, err := loader.CollectProfileNames(ctx, "testdata/invalid_syntax.yaml", false)
 		gt.Error(t, err)
 	})
 
@@ -57,7 +77,7 @@ func TestCollectProfileNames(t *testing.T) {
 		tmp := t.TempDir()
 		path := filepath.Join(tmp, "broken.hcl")
 		gt.NoError(t, os.WriteFile(path, []byte("FOO =\n"), 0o600))
-		_, err := loader.CollectProfileNames(ctx, path)
+		_, err := loader.CollectProfileNames(ctx, path, false)
 		gt.Error(t, err)
 	})
 }

--- a/pkg/loader/profile_test.go
+++ b/pkg/loader/profile_test.go
@@ -1,0 +1,63 @@
+package loader_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/m-mizutani/gt"
+	"github.com/m-mizutani/zenv/v2/pkg/loader"
+)
+
+func TestCollectProfileNames(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("collects all profile names from YAML", func(t *testing.T) {
+		names := gt.R1(loader.CollectProfileNames(ctx, "testdata/profile_basic.yaml")).NoError(t)
+		gt.Equal(t, len(names), 3)
+		for _, want := range []string{"dev", "staging", "prod"} {
+			if _, ok := names[want]; !ok {
+				t.Fatalf("expected profile %q to be present", want)
+			}
+		}
+	})
+
+	t.Run("collects all profile names from HCL", func(t *testing.T) {
+		names := gt.R1(loader.CollectProfileNames(ctx, "testdata/profile.hcl")).NoError(t)
+		gt.Equal(t, len(names), 3)
+		for _, want := range []string{"dev", "staging", "prod"} {
+			if _, ok := names[want]; !ok {
+				t.Fatalf("expected profile %q to be present", want)
+			}
+		}
+	})
+
+	t.Run("returns empty set for YAML file without any profile blocks", func(t *testing.T) {
+		names := gt.R1(loader.CollectProfileNames(ctx, "testdata/valid.yaml")).NoError(t)
+		gt.Equal(t, len(names), 0)
+	})
+
+	t.Run("returns empty set when YAML file is missing", func(t *testing.T) {
+		names := gt.R1(loader.CollectProfileNames(ctx, "testdata/does_not_exist.yaml")).NoError(t)
+		gt.Equal(t, len(names), 0)
+	})
+
+	t.Run("returns empty set when HCL file is missing", func(t *testing.T) {
+		names := gt.R1(loader.CollectProfileNames(ctx, "testdata/does_not_exist.hcl")).NoError(t)
+		gt.Equal(t, len(names), 0)
+	})
+
+	t.Run("propagates parse errors for malformed YAML", func(t *testing.T) {
+		_, err := loader.CollectProfileNames(ctx, "testdata/invalid_syntax.yaml")
+		gt.Error(t, err)
+	})
+
+	t.Run("propagates parse errors for malformed HCL", func(t *testing.T) {
+		tmp := t.TempDir()
+		path := filepath.Join(tmp, "broken.hcl")
+		gt.NoError(t, os.WriteFile(path, []byte("FOO =\n"), 0o600))
+		_, err := loader.CollectProfileNames(ctx, path)
+		gt.Error(t, err)
+	})
+}

--- a/pkg/loader/yaml_loader.go
+++ b/pkg/loader/yaml_loader.go
@@ -175,11 +175,13 @@ func loadAndMergeYAMLFiles(ctx context.Context, path string, mustExist bool) (mo
 	}
 
 	// If neither file exists, either error (when the caller insisted the file
-	// must exist) or stay silent (default-discovery mode).
+	// must exist) or stay silent (default-discovery mode). The reported Path
+	// is the original user-supplied path so the error message matches what
+	// the user actually typed (e.g. "config.yml" instead of "config.yaml").
 	if !found1 && !found2 {
 		if mustExist {
 			return nil, &model.ConfigFileError{
-				Path:   yamlPath,
+				Path:   path,
 				Format: model.FormatYAML,
 				Reason: model.ReasonNotFound,
 			}

--- a/pkg/loader/yaml_loader.go
+++ b/pkg/loader/yaml_loader.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -21,16 +22,21 @@ import (
 // CommandExecError. The tail is kept so the most relevant message survives.
 const stderrLimit = 4096
 
-func NewYAMLLoader(path string, existingVars ...[]*model.EnvVar) LoadFunc {
-	return NewYAMLLoaderWithProfile(path, "", existingVars...)
+// NewYAMLLoader builds a loader without profile awareness. When mustExist is
+// true, the absence of every candidate file (.yaml and .yml) is reported as an
+// error; otherwise the loader silently returns nil.
+func NewYAMLLoader(path string, mustExist bool, existingVars ...[]*model.EnvVar) LoadFunc {
+	return NewYAMLLoaderWithProfile(path, "", mustExist, existingVars...)
 }
 
-func NewYAMLLoaderWithProfile(path string, profile string, existingVars ...[]*model.EnvVar) LoadFunc {
+// NewYAMLLoaderWithProfile is the profile-aware variant of NewYAMLLoader. See
+// NewYAMLLoader for the mustExist semantics.
+func NewYAMLLoaderWithProfile(path string, profile string, mustExist bool, existingVars ...[]*model.EnvVar) LoadFunc {
 	return func(ctx context.Context) ([]*model.EnvVar, error) {
 		logger := ctxlog.From(ctx)
 
 		// Load both .env.yaml and .env.yml if they exist
-		config, err := loadAndMergeYAMLFiles(ctx, path)
+		config, err := loadAndMergeYAMLFiles(ctx, path, mustExist)
 		if err != nil {
 			return nil, err
 		}
@@ -97,14 +103,16 @@ func NewYAMLLoaderWithProfile(path string, profile string, existingVars ...[]*mo
 	}
 }
 
-// loadAndMergeYAMLFiles loads both .env.yaml and .env.yml if they exist and merges them
-func loadAndMergeYAMLFiles(ctx context.Context, path string) (model.YAMLConfig, error) {
+// loadAndMergeYAMLFiles loads both .env.yaml and .env.yml if they exist and merges them.
+// When mustExist is true and neither candidate file exists, a ConfigFileError with
+// ReasonNotFound is returned (using the .yaml candidate as the representative path).
+func loadAndMergeYAMLFiles(ctx context.Context, path string, mustExist bool) (model.YAMLConfig, error) {
 	logger := ctxlog.From(ctx)
 
 	// Helper function to load a single YAML file
 	loadOneFile := func(filePath string) (model.YAMLConfig, bool, error) {
 		if _, err := os.Stat(filePath); err != nil {
-			if os.IsNotExist(err) {
+			if errors.Is(err, fs.ErrNotExist) {
 				return nil, false, nil // File not found is acceptable
 			}
 			return nil, false, &model.ConfigFileError{
@@ -166,8 +174,16 @@ func loadAndMergeYAMLFiles(ctx context.Context, path string) (model.YAMLConfig, 
 		}
 	}
 
-	// If neither file exists, return nil
+	// If neither file exists, either error (when the caller insisted the file
+	// must exist) or stay silent (default-discovery mode).
 	if !found1 && !found2 {
+		if mustExist {
+			return nil, &model.ConfigFileError{
+				Path:   yamlPath,
+				Format: model.FormatYAML,
+				Reason: model.ReasonNotFound,
+			}
+		}
 		logger.Debug("no YAML files found", "yaml_path", yamlPath, "yml_path", ymlPath)
 		return nil, nil
 	}

--- a/pkg/loader/yaml_loader_test.go
+++ b/pkg/loader/yaml_loader_test.go
@@ -12,10 +12,22 @@ import (
 	"github.com/m-mizutani/zenv/v2/pkg/model"
 )
 
+// newYAMLLoader / newYAMLLoaderWithProfile are mustExist=false wrappers used
+// throughout this test file to keep existing call sites concise. The strict
+// (mustExist=true) behavior is covered in dedicated test cases that call the
+// production constructors directly.
+func newYAMLLoader(path string, existingVars ...[]*model.EnvVar) loader.LoadFunc {
+	return loader.NewYAMLLoader(path, false, existingVars...)
+}
+
+func newYAMLLoaderWithProfile(path, profile string, existingVars ...[]*model.EnvVar) loader.LoadFunc {
+	return loader.NewYAMLLoaderWithProfile(path, profile, false, existingVars...)
+}
+
 func TestYAMLLoader(t *testing.T) {
 
 	t.Run("Load valid YAML file with static values", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoader("testdata/valid.yaml")
+		loadFunc := newYAMLLoader("testdata/valid.yaml")
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		gt.Equal(t, len(envVars), 3)
@@ -36,7 +48,7 @@ func TestYAMLLoader(t *testing.T) {
 	})
 
 	t.Run("Load YAML file with file reference", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoader("testdata/with_file.yaml")
+		loadFunc := newYAMLLoader("testdata/with_file.yaml")
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		gt.Equal(t, len(envVars), 1)
@@ -46,7 +58,7 @@ func TestYAMLLoader(t *testing.T) {
 	})
 
 	t.Run("File path is resolved relative to YAML file directory", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoader("testdata/subdir/with_file_relative.yaml")
+		loadFunc := newYAMLLoader("testdata/subdir/with_file_relative.yaml")
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		gt.Equal(t, len(envVars), 1)
@@ -55,7 +67,7 @@ func TestYAMLLoader(t *testing.T) {
 	})
 
 	t.Run("File path in same directory as YAML file", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoader("testdata/subdir/with_file_same_dir.yaml")
+		loadFunc := newYAMLLoader("testdata/subdir/with_file_same_dir.yaml")
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		gt.Equal(t, len(envVars), 1)
@@ -74,7 +86,7 @@ func TestYAMLLoader(t *testing.T) {
 		yamlPath := filepath.Join(tmpDir, ".env.yaml")
 		gt.NoError(t, os.WriteFile(yamlPath, []byte(yamlContent), 0600))
 
-		loadFunc := loader.NewYAMLLoader(yamlPath)
+		loadFunc := newYAMLLoader(yamlPath)
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		gt.Equal(t, len(envVars), 1)
@@ -83,7 +95,7 @@ func TestYAMLLoader(t *testing.T) {
 	})
 
 	t.Run("Load YAML file with command execution", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoader("testdata/with_command.yaml")
+		loadFunc := newYAMLLoader("testdata/with_command.yaml")
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		gt.Equal(t, len(envVars), 1)
@@ -92,14 +104,24 @@ func TestYAMLLoader(t *testing.T) {
 		gt.Equal(t, envVars[0].Source, model.SourceYAML)
 	})
 
-	t.Run("Handle non-existent file", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoader("testdata/non_existent.yaml")
+	t.Run("Handle non-existent file when mustExist=false", func(t *testing.T) {
+		loadFunc := newYAMLLoader("testdata/non_existent.yaml")
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 		gt.Nil(t, envVars)
 	})
 
+	t.Run("Error on non-existent file when mustExist=true", func(t *testing.T) {
+		loadFunc := loader.NewYAMLLoader("testdata/non_existent.yaml", true)
+		_, err := loadFunc(context.Background())
+		gt.Error(t, err)
+		var cfgErr *model.ConfigFileError
+		gt.True(t, errors.As(err, &cfgErr))
+		gt.Equal(t, cfgErr.Format, model.FormatYAML)
+		gt.Equal(t, cfgErr.Reason, model.ReasonNotFound)
+	})
+
 	t.Run("Handle invalid YAML syntax", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoader("testdata/invalid_syntax.yaml")
+		loadFunc := newYAMLLoader("testdata/invalid_syntax.yaml")
 		_, err := loadFunc(context.Background())
 		gt.Error(t, err)
 		var cfgErr *model.ConfigFileError
@@ -109,14 +131,14 @@ func TestYAMLLoader(t *testing.T) {
 	})
 
 	t.Run("Handle validation errors", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoader("testdata/validation_error.yaml")
+		loadFunc := newYAMLLoader("testdata/validation_error.yaml")
 		_, err := loadFunc(context.Background())
 		gt.Error(t, err)
 		gt.S(t, err.Error()).Contains("multiple value types specified")
 	})
 
 	t.Run("Handle missing file reference", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoader("testdata/missing_file.yaml")
+		loadFunc := newYAMLLoader("testdata/missing_file.yaml")
 		_, err := loadFunc(context.Background())
 		gt.Error(t, err)
 		var resolveErr *model.ResolveError
@@ -125,14 +147,14 @@ func TestYAMLLoader(t *testing.T) {
 	})
 
 	t.Run("Handle command execution failure", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoader("testdata/command_failure.yaml")
+		loadFunc := newYAMLLoader("testdata/command_failure.yaml")
 		_, err := loadFunc(context.Background())
 		// The 'false' command exits with non-zero status
 		gt.Error(t, err)
 	})
 
 	t.Run("Load YAML file with alias", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoader("testdata/alias.yaml")
+		loadFunc := newYAMLLoader("testdata/alias.yaml")
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		// Check that alias resolves correctly
@@ -151,7 +173,7 @@ func TestYAMLLoader(t *testing.T) {
 		// Set a system environment variable for testing
 		t.Setenv("TEST_SYSTEM_VAR", "system_value")
 
-		loadFunc := loader.NewYAMLLoader("testdata/alias_system.yaml")
+		loadFunc := newYAMLLoader("testdata/alias_system.yaml")
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		// Find the MY_VAR environment variable
@@ -183,7 +205,7 @@ ALIAS_TO_SHARED:
 		gt.R1(tmpFile.WriteString(yamlContent)).NoError(t)
 		tmpFile.Close()
 
-		loadFunc := loader.NewYAMLLoader(tmpFile.Name())
+		loadFunc := newYAMLLoader(tmpFile.Name())
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		// Find the ALIAS_TO_SHARED variable
@@ -212,7 +234,7 @@ ALIAS_TO_EMPTY:
 		gt.R1(tmpFile.WriteString(yamlContent)).NoError(t)
 		tmpFile.Close()
 
-		loadFunc := loader.NewYAMLLoader(tmpFile.Name())
+		loadFunc := newYAMLLoader(tmpFile.Name())
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		// Find the ALIAS_TO_EMPTY variable
@@ -231,7 +253,7 @@ ALIAS_TO_EMPTY:
 	})
 
 	t.Run("Alias with non-existent target returns error", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoader("testdata/alias_missing.yaml")
+		loadFunc := newYAMLLoader("testdata/alias_missing.yaml")
 		_, err := loadFunc(context.Background())
 		gt.Error(t, err)
 		var refErr *model.ReferenceError
@@ -240,14 +262,14 @@ ALIAS_TO_EMPTY:
 	})
 
 	t.Run("Handle circular alias reference", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoader("testdata/circular_alias.yaml")
+		loadFunc := newYAMLLoader("testdata/circular_alias.yaml")
 		_, err := loadFunc(context.Background())
 		gt.Error(t, err)
 		gt.S(t, err.Error()).Contains("circular reference")
 	})
 
 	t.Run("Validation error when multiple types including alias", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoader("testdata/alias_multiple_types.yaml")
+		loadFunc := newYAMLLoader("testdata/alias_multiple_types.yaml")
 		_, err := loadFunc(context.Background())
 		gt.Error(t, err)
 		gt.S(t, err.Error()).Contains("multiple value types specified")
@@ -255,7 +277,7 @@ ALIAS_TO_EMPTY:
 
 	// Template tests
 	t.Run("Load YAML file with basic template", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoader("testdata/template.yaml")
+		loadFunc := newYAMLLoader("testdata/template.yaml")
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		// Check that template resolves correctly
@@ -276,7 +298,7 @@ ALIAS_TO_EMPTY:
 	})
 
 	t.Run("Template with conditional logic", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoader("testdata/template.yaml")
+		loadFunc := newYAMLLoader("testdata/template.yaml")
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		vars := make(map[string]string)
@@ -303,7 +325,7 @@ FROM_SYSTEM:
 		gt.R1(tmpFile.WriteString(yamlContent)).NoError(t)
 		tmpFile.Close()
 
-		loadFunc := loader.NewYAMLLoader(tmpFile.Name())
+		loadFunc := newYAMLLoader(tmpFile.Name())
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		// Find the FROM_SYSTEM variable
@@ -319,7 +341,7 @@ FROM_SYSTEM:
 	})
 
 	t.Run("Template with empty reference", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoader("testdata/template_complex.yaml")
+		loadFunc := newYAMLLoader("testdata/template_complex.yaml")
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		vars := make(map[string]string)
@@ -336,7 +358,7 @@ FROM_SYSTEM:
 	})
 
 	t.Run("Template with nested references", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoader("testdata/template_complex.yaml")
+		loadFunc := newYAMLLoader("testdata/template_complex.yaml")
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		vars := make(map[string]string)
@@ -355,7 +377,7 @@ FROM_SYSTEM:
 	})
 
 	t.Run("Template with complex logic", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoader("testdata/template_complex.yaml")
+		loadFunc := newYAMLLoader("testdata/template_complex.yaml")
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		vars := make(map[string]string)
@@ -368,7 +390,7 @@ FROM_SYSTEM:
 	})
 
 	t.Run("Handle circular template reference", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoader("testdata/template_circular.yaml")
+		loadFunc := newYAMLLoader("testdata/template_circular.yaml")
 		_, err := loadFunc(context.Background())
 		gt.Error(t, err)
 		gt.S(t, err.Error()).Contains("circular reference")
@@ -389,7 +411,7 @@ VAR_NAME:
 		gt.R1(tmpFile.WriteString(yamlContent)).NoError(t)
 		tmpFile.Close()
 
-		loadFunc := loader.NewYAMLLoader(tmpFile.Name())
+		loadFunc := newYAMLLoader(tmpFile.Name())
 		_, err := loadFunc(context.Background())
 		gt.Error(t, err)
 		var resolveErr *model.ResolveError
@@ -408,7 +430,7 @@ NO_REFS:
 		gt.R1(tmpFile.WriteString(yamlContent)).NoError(t)
 		tmpFile.Close()
 
-		loadFunc := loader.NewYAMLLoader(tmpFile.Name())
+		loadFunc := newYAMLLoader(tmpFile.Name())
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		gt.Equal(t, len(envVars), 1)
@@ -427,7 +449,7 @@ REFS_ONLY:
 		gt.R1(tmpFile.WriteString(yamlContent)).NoError(t)
 		tmpFile.Close()
 
-		loadFunc := loader.NewYAMLLoader(tmpFile.Name())
+		loadFunc := newYAMLLoader(tmpFile.Name())
 		_, err := loadFunc(context.Background())
 		gt.Error(t, err)
 		gt.S(t, err.Error()).Contains("refs can only be used with value or command")
@@ -445,7 +467,7 @@ MULTIPLE_TYPES:
 		gt.R1(tmpFile.WriteString(yamlContent)).NoError(t)
 		tmpFile.Close()
 
-		loadFunc := loader.NewYAMLLoader(tmpFile.Name())
+		loadFunc := newYAMLLoader(tmpFile.Name())
 		_, err := loadFunc(context.Background())
 		gt.Error(t, err)
 		gt.S(t, err.Error()).Contains("multiple value types specified")
@@ -465,7 +487,7 @@ ALIAS_VAR:
 		gt.R1(tmpFile.WriteString(yamlContent)).NoError(t)
 		tmpFile.Close()
 
-		loadFunc := loader.NewYAMLLoader(tmpFile.Name())
+		loadFunc := newYAMLLoader(tmpFile.Name())
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		vars := make(map[string]string)
@@ -479,7 +501,7 @@ ALIAS_VAR:
 	})
 
 	t.Run("Alias pointing to template variable with refs", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoader("testdata/alias_to_template.yaml")
+		loadFunc := newYAMLLoader("testdata/alias_to_template.yaml")
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		vars := make(map[string]string)
@@ -498,7 +520,7 @@ ALIAS_VAR:
 	})
 
 	t.Run("Handle complex circular references (alias->template->alias)", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoader("testdata/complex_circular.yaml")
+		loadFunc := newYAMLLoader("testdata/complex_circular.yaml")
 		_, err := loadFunc(context.Background())
 
 		// Should detect circular reference in any of the complex cases
@@ -524,7 +546,7 @@ VAR_C:
 		gt.R1(tmpFile.WriteString(yamlContent)).NoError(t)
 		tmpFile.Close()
 
-		loadFunc := loader.NewYAMLLoader(tmpFile.Name())
+		loadFunc := newYAMLLoader(tmpFile.Name())
 		_, err := loadFunc(context.Background())
 
 		gt.Error(t, err)
@@ -546,7 +568,7 @@ SELF_ALIAS:
 		gt.R1(tmpFile.WriteString(yamlContent)).NoError(t)
 		tmpFile.Close()
 
-		loadFunc := loader.NewYAMLLoader(tmpFile.Name())
+		loadFunc := newYAMLLoader(tmpFile.Name())
 		_, err := loadFunc(context.Background())
 
 		gt.Error(t, err)
@@ -573,7 +595,7 @@ DB_URL:
 		}
 
 		// Create YAML loader with existing variables
-		loader := loader.NewYAMLLoader(yamlPath, existingVars)
+		loader := newYAMLLoader(yamlPath, existingVars)
 
 		// Load and resolve
 		vars, err := loader(context.Background())
@@ -599,7 +621,7 @@ PRIMARY_DB:
 		}
 
 		// Create YAML loader with existing variables
-		loader := loader.NewYAMLLoader(yamlPath, existingVars)
+		loader := newYAMLLoader(yamlPath, existingVars)
 
 		// Load and resolve
 		vars, err := loader(context.Background())
@@ -633,7 +655,7 @@ RESULT:
 		}
 
 		// Create YAML loader with existing variables
-		loader := loader.NewYAMLLoader(yamlPath, existingVars)
+		loader := newYAMLLoader(yamlPath, existingVars)
 
 		// Load and resolve
 		vars, err := loader(context.Background())
@@ -680,7 +702,7 @@ FULL_URL:
 		}
 
 		// Create YAML loader with existing variables
-		loader := loader.NewYAMLLoader(yamlPath, existingVars)
+		loader := newYAMLLoader(yamlPath, existingVars)
 
 		// Load and resolve
 		vars, err := loader(context.Background())
@@ -710,7 +732,7 @@ SIMPLE_VAR:
 		gt.NoError(t, os.WriteFile(yamlPath, []byte(yamlContent), 0644))
 
 		// Create YAML loader without external variables (backward compatibility)
-		loader := loader.NewYAMLLoader(yamlPath)
+		loader := newYAMLLoader(yamlPath)
 
 		// Load and resolve
 		vars, err := loader(context.Background())
@@ -732,7 +754,7 @@ TEST_TEMPLATE:
 		gt.NoError(t, os.WriteFile(yamlPath, []byte(yamlContent), 0644))
 
 		// Create YAML loader
-		loader := loader.NewYAMLLoader(yamlPath)
+		loader := newYAMLLoader(yamlPath)
 
 		// Load and resolve - should error
 		_, err := loader(context.Background())
@@ -753,7 +775,7 @@ TEST_ALIAS:
 		gt.NoError(t, os.WriteFile(yamlPath, []byte(yamlContent), 0644))
 
 		// Create YAML loader
-		loader := loader.NewYAMLLoader(yamlPath)
+		loader := newYAMLLoader(yamlPath)
 
 		// Load and resolve - should error
 		_, err := loader(context.Background())
@@ -780,7 +802,7 @@ TEST_EMPTY:
 		}
 
 		// Create YAML loader with empty variable
-		loader1 := loader.NewYAMLLoader(yamlPath1, existingVars)
+		loader1 := newYAMLLoader(yamlPath1, existingVars)
 
 		// Load and resolve - should succeed with empty string
 		vars, err := loader1(context.Background())
@@ -799,7 +821,7 @@ TEST_MISSING:
 		gt.NoError(t, os.WriteFile(yamlPath2, []byte(yamlContent2), 0644))
 
 		// Create YAML loader without the required variable
-		loader2 := loader.NewYAMLLoader(yamlPath2, existingVars) // MISSING_VAR not in existingVars
+		loader2 := newYAMLLoader(yamlPath2, existingVars) // MISSING_VAR not in existingVars
 
 		// Load and resolve - should error
 		_, err = loader2(context.Background())
@@ -810,7 +832,7 @@ TEST_MISSING:
 	})
 
 	t.Run("Load YAML file with simple format only", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoader("testdata/simple_format.yaml")
+		loadFunc := newYAMLLoader("testdata/simple_format.yaml")
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		gt.Equal(t, len(envVars), 4)
@@ -832,7 +854,7 @@ TEST_MISSING:
 	})
 
 	t.Run("Load YAML file with mixed format", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoader("testdata/mixed_format.yaml")
+		loadFunc := newYAMLLoader("testdata/mixed_format.yaml")
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		// All top-level keys are loaded (no section scope issue in YAML)
@@ -876,7 +898,7 @@ TEST_MISSING:
 		err := os.WriteFile(tmpFile, []byte("PORT: 123\nDEBUG: true\nNAME: \"test\""), 0644)
 		gt.NoError(t, err)
 
-		loadFunc := loader.NewYAMLLoader(tmpFile)
+		loadFunc := newYAMLLoader(tmpFile)
 		envVars, err := loadFunc(context.Background())
 		gt.NoError(t, err)
 		gt.Equal(t, len(envVars), 3)
@@ -893,7 +915,7 @@ TEST_MISSING:
 	})
 
 	t.Run("Command with refs", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoader("testdata/command_with_refs.yaml")
+		loadFunc := newYAMLLoader("testdata/command_with_refs.yaml")
 		envVars, err := loadFunc(context.Background())
 		gt.NoError(t, err)
 
@@ -932,14 +954,14 @@ TEST_MISSING:
 	})
 
 	t.Run("Command with circular refs should fail", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoader("testdata/command_circular_refs.yaml")
+		loadFunc := newYAMLLoader("testdata/command_circular_refs.yaml")
 		_, err := loadFunc(context.Background())
 		gt.Error(t, err)
 		gt.S(t, err.Error()).Contains("circular reference")
 	})
 
 	t.Run("Command without refs should work", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoader("testdata/with_command.yaml")
+		loadFunc := newYAMLLoader("testdata/with_command.yaml")
 		envVars, err := loadFunc(context.Background())
 		gt.NoError(t, err)
 
@@ -955,7 +977,7 @@ TEST_MISSING:
 
 func TestProfileBasic(t *testing.T) {
 	t.Run("loads default values when no profile specified", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoaderWithProfile("testdata/profile_basic.yaml", "", nil)
+		loadFunc := newYAMLLoaderWithProfile("testdata/profile_basic.yaml", "", nil)
 		envVars, err := loadFunc(context.Background())
 		gt.NoError(t, err)
 
@@ -970,7 +992,7 @@ func TestProfileBasic(t *testing.T) {
 	})
 
 	t.Run("loads dev profile values", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoaderWithProfile("testdata/profile_basic.yaml", "dev", nil)
+		loadFunc := newYAMLLoaderWithProfile("testdata/profile_basic.yaml", "dev", nil)
 		envVars, err := loadFunc(context.Background())
 		gt.NoError(t, err)
 
@@ -985,7 +1007,7 @@ func TestProfileBasic(t *testing.T) {
 	})
 
 	t.Run("loads staging profile values", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoaderWithProfile("testdata/profile_basic.yaml", "staging", nil)
+		loadFunc := newYAMLLoaderWithProfile("testdata/profile_basic.yaml", "staging", nil)
 		envVars, err := loadFunc(context.Background())
 		gt.NoError(t, err)
 
@@ -1000,7 +1022,7 @@ func TestProfileBasic(t *testing.T) {
 	})
 
 	t.Run("loads prod profile values", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoaderWithProfile("testdata/profile_basic.yaml", "prod", nil)
+		loadFunc := newYAMLLoaderWithProfile("testdata/profile_basic.yaml", "prod", nil)
 		envVars, err := loadFunc(context.Background())
 		gt.NoError(t, err)
 
@@ -1015,7 +1037,7 @@ func TestProfileBasic(t *testing.T) {
 	})
 
 	t.Run("unknown profile uses default values", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoaderWithProfile("testdata/profile_basic.yaml", "unknown", nil)
+		loadFunc := newYAMLLoaderWithProfile("testdata/profile_basic.yaml", "unknown", nil)
 		envVars, err := loadFunc(context.Background())
 		gt.NoError(t, err)
 
@@ -1032,7 +1054,7 @@ func TestProfileBasic(t *testing.T) {
 
 func TestProfileUnset(t *testing.T) {
 	t.Run("empty object unsets variable in prod profile", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoaderWithProfile("testdata/profile_unset.yaml", "prod", nil)
+		loadFunc := newYAMLLoaderWithProfile("testdata/profile_unset.yaml", "prod", nil)
 		envVars, err := loadFunc(context.Background())
 		gt.NoError(t, err)
 
@@ -1053,7 +1075,7 @@ func TestProfileUnset(t *testing.T) {
 	})
 
 	t.Run("dev profile has all variables", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoaderWithProfile("testdata/profile_unset.yaml", "dev", nil)
+		loadFunc := newYAMLLoaderWithProfile("testdata/profile_unset.yaml", "dev", nil)
 		envVars, err := loadFunc(context.Background())
 		gt.NoError(t, err)
 
@@ -1068,7 +1090,7 @@ func TestProfileUnset(t *testing.T) {
 	})
 
 	t.Run("default profile has all variables", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoaderWithProfile("testdata/profile_unset.yaml", "", nil)
+		loadFunc := newYAMLLoaderWithProfile("testdata/profile_unset.yaml", "", nil)
 		envVars, err := loadFunc(context.Background())
 		gt.NoError(t, err)
 
@@ -1085,7 +1107,7 @@ func TestProfileUnset(t *testing.T) {
 
 func TestProfileAdvanced(t *testing.T) {
 	t.Run("profile with file reference", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoaderWithProfile("testdata/profile_advanced.yaml", "dev", nil)
+		loadFunc := newYAMLLoaderWithProfile("testdata/profile_advanced.yaml", "dev", nil)
 		envVars, err := loadFunc(context.Background())
 		gt.NoError(t, err)
 
@@ -1099,7 +1121,7 @@ func TestProfileAdvanced(t *testing.T) {
 	})
 
 	t.Run("profile with value override", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoaderWithProfile("testdata/profile_advanced.yaml", "staging", nil)
+		loadFunc := newYAMLLoaderWithProfile("testdata/profile_advanced.yaml", "staging", nil)
 		envVars, err := loadFunc(context.Background())
 		gt.NoError(t, err)
 
@@ -1113,7 +1135,7 @@ func TestProfileAdvanced(t *testing.T) {
 	})
 
 	t.Run("profile with command execution", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoaderWithProfile("testdata/profile_advanced.yaml", "prod", nil)
+		loadFunc := newYAMLLoaderWithProfile("testdata/profile_advanced.yaml", "prod", nil)
 		envVars, err := loadFunc(context.Background())
 		gt.NoError(t, err)
 
@@ -1126,7 +1148,7 @@ func TestProfileAdvanced(t *testing.T) {
 	})
 
 	t.Run("profile with alias", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoaderWithProfile("testdata/profile_advanced.yaml", "staging", nil)
+		loadFunc := newYAMLLoaderWithProfile("testdata/profile_advanced.yaml", "staging", nil)
 		envVars, err := loadFunc(context.Background())
 		gt.NoError(t, err)
 
@@ -1140,7 +1162,7 @@ func TestProfileAdvanced(t *testing.T) {
 	})
 
 	t.Run("profile with template", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoaderWithProfile("testdata/profile_advanced.yaml", "dev", nil)
+		loadFunc := newYAMLLoaderWithProfile("testdata/profile_advanced.yaml", "dev", nil)
 		envVars, err := loadFunc(context.Background())
 		gt.NoError(t, err)
 
@@ -1158,7 +1180,7 @@ func TestProfileAdvanced(t *testing.T) {
 
 func TestProfileCompatibility(t *testing.T) {
 	t.Run("backward compatibility with no profile", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoaderWithProfile("testdata/profile_compat.yaml", "", nil)
+		loadFunc := newYAMLLoaderWithProfile("testdata/profile_compat.yaml", "", nil)
 		envVars, err := loadFunc(context.Background())
 		gt.NoError(t, err)
 
@@ -1176,7 +1198,7 @@ func TestProfileCompatibility(t *testing.T) {
 	})
 
 	t.Run("profile selection with mixed variables", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoaderWithProfile("testdata/profile_compat.yaml", "dev", nil)
+		loadFunc := newYAMLLoaderWithProfile("testdata/profile_compat.yaml", "dev", nil)
 		envVars, err := loadFunc(context.Background())
 		gt.NoError(t, err)
 
@@ -1196,7 +1218,7 @@ func TestProfileCompatibility(t *testing.T) {
 	})
 
 	t.Run("profile with partial coverage", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoaderWithProfile("testdata/profile_compat.yaml", "staging", nil)
+		loadFunc := newYAMLLoaderWithProfile("testdata/profile_compat.yaml", "staging", nil)
 		envVars, err := loadFunc(context.Background())
 		gt.NoError(t, err)
 
@@ -1214,7 +1236,7 @@ func TestProfileCompatibility(t *testing.T) {
 
 func TestProfileNestedValidation(t *testing.T) {
 	t.Run("nested profile in YAML should be rejected", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoaderWithProfile("testdata/profile_nested.yaml", "", nil)
+		loadFunc := newYAMLLoaderWithProfile("testdata/profile_nested.yaml", "", nil)
 		_, err := loadFunc(context.Background())
 		gt.Error(t, err)
 		gt.S(t, err.Error()).Contains("nested profile")
@@ -1223,7 +1245,7 @@ func TestProfileNestedValidation(t *testing.T) {
 
 func TestProfileDottedKeyFormat(t *testing.T) {
 	t.Run("self-referencing dotted key format", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoaderWithProfile("testdata/profile_self_reference.yaml", "dev", nil)
+		loadFunc := newYAMLLoaderWithProfile("testdata/profile_self_reference.yaml", "dev", nil)
 		envVars, err := loadFunc(context.Background())
 		gt.NoError(t, err)
 
@@ -1236,7 +1258,7 @@ func TestProfileDottedKeyFormat(t *testing.T) {
 	})
 
 	t.Run("self-referencing dotted key default", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoaderWithProfile("testdata/profile_self_reference.yaml", "", nil)
+		loadFunc := newYAMLLoaderWithProfile("testdata/profile_self_reference.yaml", "", nil)
 		envVars, err := loadFunc(context.Background())
 		gt.NoError(t, err)
 
@@ -1249,7 +1271,7 @@ func TestProfileDottedKeyFormat(t *testing.T) {
 	})
 
 	t.Run("dotted key format with dev profile", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoaderWithProfile("testdata/profile_dotted.yaml", "dev", nil)
+		loadFunc := newYAMLLoaderWithProfile("testdata/profile_dotted.yaml", "dev", nil)
 		envVars, err := loadFunc(context.Background())
 		gt.NoError(t, err)
 
@@ -1263,7 +1285,7 @@ func TestProfileDottedKeyFormat(t *testing.T) {
 	})
 
 	t.Run("dotted key format with staging profile", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoaderWithProfile("testdata/profile_dotted.yaml", "staging", nil)
+		loadFunc := newYAMLLoaderWithProfile("testdata/profile_dotted.yaml", "staging", nil)
 		envVars, err := loadFunc(context.Background())
 		gt.NoError(t, err)
 
@@ -1277,7 +1299,7 @@ func TestProfileDottedKeyFormat(t *testing.T) {
 	})
 
 	t.Run("dotted key format with prod profile", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoaderWithProfile("testdata/profile_dotted.yaml", "prod", nil)
+		loadFunc := newYAMLLoaderWithProfile("testdata/profile_dotted.yaml", "prod", nil)
 		envVars, err := loadFunc(context.Background())
 		gt.NoError(t, err)
 
@@ -1291,7 +1313,7 @@ func TestProfileDottedKeyFormat(t *testing.T) {
 	})
 
 	t.Run("dotted key format with default profile", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoaderWithProfile("testdata/profile_dotted.yaml", "", nil)
+		loadFunc := newYAMLLoaderWithProfile("testdata/profile_dotted.yaml", "", nil)
 		envVars, err := loadFunc(context.Background())
 		gt.NoError(t, err)
 
@@ -1307,7 +1329,7 @@ func TestProfileDottedKeyFormat(t *testing.T) {
 
 func TestProfileInlineFormat(t *testing.T) {
 	t.Run("inline table format should work", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoaderWithProfile("testdata/profile_inline.yaml", "dev", nil)
+		loadFunc := newYAMLLoaderWithProfile("testdata/profile_inline.yaml", "dev", nil)
 		envVars, err := loadFunc(context.Background())
 		gt.NoError(t, err)
 
@@ -1321,7 +1343,7 @@ func TestProfileInlineFormat(t *testing.T) {
 	})
 
 	t.Run("inline format with staging profile", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoaderWithProfile("testdata/profile_inline.yaml", "staging", nil)
+		loadFunc := newYAMLLoaderWithProfile("testdata/profile_inline.yaml", "staging", nil)
 		envVars, err := loadFunc(context.Background())
 		gt.NoError(t, err)
 
@@ -1335,7 +1357,7 @@ func TestProfileInlineFormat(t *testing.T) {
 	})
 
 	t.Run("inline string format should work", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoaderWithProfile("testdata/profile_inline_string.yaml", "dev", nil)
+		loadFunc := newYAMLLoaderWithProfile("testdata/profile_inline_string.yaml", "dev", nil)
 		envVars, err := loadFunc(context.Background())
 		gt.NoError(t, err)
 
@@ -1349,7 +1371,7 @@ func TestProfileInlineFormat(t *testing.T) {
 	})
 
 	t.Run("inline string format default values", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoaderWithProfile("testdata/profile_inline_string.yaml", "", nil)
+		loadFunc := newYAMLLoaderWithProfile("testdata/profile_inline_string.yaml", "", nil)
 		envVars, err := loadFunc(context.Background())
 		gt.NoError(t, err)
 
@@ -1365,7 +1387,7 @@ func TestProfileInlineFormat(t *testing.T) {
 
 func TestProfileNilHandling(t *testing.T) {
 	t.Run("nil profile value should be skipped", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoaderWithProfile("testdata/profile_unset.yaml", "nonexistent", nil)
+		loadFunc := newYAMLLoaderWithProfile("testdata/profile_unset.yaml", "nonexistent", nil)
 		envVars, err := loadFunc(context.Background())
 		gt.NoError(t, err)
 
@@ -1380,7 +1402,7 @@ func TestProfileNilHandling(t *testing.T) {
 	})
 
 	t.Run("empty object unsets variable correctly", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoaderWithProfile("testdata/profile_unset.yaml", "prod", nil)
+		loadFunc := newYAMLLoaderWithProfile("testdata/profile_unset.yaml", "prod", nil)
 		envVars, err := loadFunc(context.Background())
 		gt.NoError(t, err)
 
@@ -1408,7 +1430,7 @@ API_KEY: "secret123"
 `
 		gt.NoError(t, os.WriteFile(ymlPath, []byte(ymlContent), 0644))
 
-		loadFunc := loader.NewYAMLLoader(filepath.Join(tmpDir, ".env.yaml"))
+		loadFunc := newYAMLLoader(filepath.Join(tmpDir, ".env.yaml"))
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		gt.Equal(t, len(envVars), 2)
@@ -1430,7 +1452,7 @@ API_KEY: "yaml-secret"
 `
 		gt.NoError(t, os.WriteFile(yamlPath, []byte(yamlContent), 0644))
 
-		loadFunc := loader.NewYAMLLoader(yamlPath)
+		loadFunc := newYAMLLoader(yamlPath)
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		gt.Equal(t, len(envVars), 2)
@@ -1459,7 +1481,7 @@ LOG_LEVEL: "info"
 		gt.NoError(t, os.WriteFile(yamlPath, []byte(yamlContent), 0644))
 		gt.NoError(t, os.WriteFile(ymlPath, []byte(ymlContent), 0644))
 
-		loadFunc := loader.NewYAMLLoader(yamlPath)
+		loadFunc := newYAMLLoader(yamlPath)
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		gt.Equal(t, len(envVars), 4)
@@ -1493,7 +1515,7 @@ REDIS_URL: "redis://localhost:6379"
 		gt.NoError(t, os.WriteFile(yamlPath, []byte(yamlContent), 0644))
 		gt.NoError(t, os.WriteFile(ymlPath, []byte(ymlContent), 0644))
 
-		loadFunc := loader.NewYAMLLoader(yamlPath)
+		loadFunc := newYAMLLoader(yamlPath)
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		varMap := make(map[string]string)
@@ -1524,7 +1546,7 @@ TEMPLATE:
 		gt.NoError(t, os.WriteFile(yamlPath, []byte(yamlContent), 0644))
 		gt.NoError(t, os.WriteFile(ymlPath, []byte(ymlContent), 0644))
 
-		loadFunc := loader.NewYAMLLoader(yamlPath)
+		loadFunc := newYAMLLoader(yamlPath)
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		varMap := make(map[string]string)
@@ -1558,17 +1580,17 @@ API_URL:
 		gt.NoError(t, os.WriteFile(ymlPath, []byte(ymlContent), 0644))
 
 		// Test dev profile
-		loadFuncDev := loader.NewYAMLLoaderWithProfile(yamlPath, "dev", nil)
+		loadFuncDev := newYAMLLoaderWithProfile(yamlPath, "dev", nil)
 		envVarsDev := gt.R1(loadFuncDev(context.Background())).NoError(t)
 		gt.Equal(t, envVarsDev[0].Value, "http://localhost:8080")
 
 		// Test staging profile
-		loadFuncStaging := loader.NewYAMLLoaderWithProfile(yamlPath, "staging", nil)
+		loadFuncStaging := newYAMLLoaderWithProfile(yamlPath, "staging", nil)
 		envVarsStaging := gt.R1(loadFuncStaging(context.Background())).NoError(t)
 		gt.Equal(t, envVarsStaging[0].Value, "https://staging.example.com")
 
 		// Test default profile
-		loadFuncDefault := loader.NewYAMLLoaderWithProfile(yamlPath, "", nil)
+		loadFuncDefault := newYAMLLoaderWithProfile(yamlPath, "", nil)
 		envVarsDefault := gt.R1(loadFuncDefault(context.Background())).NoError(t)
 		gt.Equal(t, envVarsDefault[0].Value, "https://api.example.com")
 	})
@@ -1594,7 +1616,7 @@ API_URL:
 		gt.NoError(t, os.WriteFile(yamlPath, []byte(yamlContent), 0644))
 		gt.NoError(t, os.WriteFile(ymlPath, []byte(ymlContent), 0644))
 
-		loadFunc := loader.NewYAMLLoaderWithProfile(yamlPath, "dev", nil)
+		loadFunc := newYAMLLoaderWithProfile(yamlPath, "dev", nil)
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 		gt.Equal(t, envVars[0].Value, "http://localhost:9090")
 	})
@@ -1615,7 +1637,7 @@ DATABASE_URL:
 		gt.NoError(t, os.WriteFile(yamlPath, []byte(yamlContent), 0644))
 		gt.NoError(t, os.WriteFile(ymlPath, []byte(ymlContent), 0644))
 
-		loadFunc := loader.NewYAMLLoader(yamlPath)
+		loadFunc := newYAMLLoader(yamlPath)
 		_, err := loadFunc(context.Background())
 		gt.Error(t, err)
 		gt.S(t, err.Error()).Contains("conflicting field \"value\"")
@@ -1638,7 +1660,7 @@ SSL_CERT:
 		gt.NoError(t, os.WriteFile(yamlPath, []byte(yamlContent), 0644))
 		gt.NoError(t, os.WriteFile(ymlPath, []byte(ymlContent), 0644))
 
-		loadFunc := loader.NewYAMLLoader(yamlPath)
+		loadFunc := newYAMLLoader(yamlPath)
 		_, err := loadFunc(context.Background())
 		gt.Error(t, err)
 		gt.S(t, err.Error()).Contains("conflicting field \"file\"")
@@ -1661,7 +1683,7 @@ HOSTNAME:
 		gt.NoError(t, os.WriteFile(yamlPath, []byte(yamlContent), 0644))
 		gt.NoError(t, os.WriteFile(ymlPath, []byte(ymlContent), 0644))
 
-		loadFunc := loader.NewYAMLLoader(yamlPath)
+		loadFunc := newYAMLLoader(yamlPath)
 		_, err := loadFunc(context.Background())
 		gt.Error(t, err)
 		gt.S(t, err.Error()).Contains("conflicting field \"command\"")
@@ -1686,7 +1708,7 @@ DB_URL:
 		gt.NoError(t, os.WriteFile(yamlPath, []byte(yamlContent), 0644))
 		gt.NoError(t, os.WriteFile(ymlPath, []byte(ymlContent), 0644))
 
-		loadFunc := loader.NewYAMLLoader(yamlPath)
+		loadFunc := newYAMLLoader(yamlPath)
 		_, err := loadFunc(context.Background())
 		gt.Error(t, err)
 		gt.S(t, err.Error()).Contains("conflicting field \"alias\"")
@@ -1697,7 +1719,7 @@ DB_URL:
 		tmpDir := t.TempDir()
 		yamlPath := filepath.Join(tmpDir, ".env.yaml")
 
-		loadFunc := loader.NewYAMLLoader(yamlPath)
+		loadFunc := newYAMLLoader(yamlPath)
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 		gt.Nil(t, envVars)
 	})
@@ -1710,7 +1732,7 @@ API_KEY: "secret123"`
 		gt.NoError(t, os.WriteFile(ymlPath, []byte(ymlContent), 0644))
 
 		// Pass .yml path directly - should not try to load the same file twice
-		loadFunc := loader.NewYAMLLoader(ymlPath)
+		loadFunc := newYAMLLoader(ymlPath)
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		gt.Equal(t, len(envVars), 2)
@@ -1731,7 +1753,7 @@ PORT: "8080"`
 		gt.NoError(t, os.WriteFile(yamlPath, []byte(yamlContent), 0644))
 
 		// Pass .yaml path directly
-		loadFunc := loader.NewYAMLLoader(yamlPath)
+		loadFunc := newYAMLLoader(yamlPath)
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		gt.Equal(t, len(envVars), 2)
@@ -1748,7 +1770,7 @@ PORT: "8080"`
 func TestYAMLLoaderSecret(t *testing.T) {
 
 	t.Run("Secret flag is propagated to EnvVar", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoader("testdata/secret.yaml")
+		loadFunc := newYAMLLoader("testdata/secret.yaml")
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		gt.Equal(t, len(envVars), 3)
@@ -1764,7 +1786,7 @@ func TestYAMLLoaderSecret(t *testing.T) {
 	})
 
 	t.Run("Secret flag inherited from base in profile", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoaderWithProfile("testdata/secret_profile.yaml", "dev")
+		loadFunc := newYAMLLoaderWithProfile("testdata/secret_profile.yaml", "dev")
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		varMap := make(map[string]*model.EnvVar)
@@ -1779,7 +1801,7 @@ func TestYAMLLoaderSecret(t *testing.T) {
 	})
 
 	t.Run("Secret flag not set in profile when base has no secret", func(t *testing.T) {
-		loadFunc := loader.NewYAMLLoaderWithProfile("testdata/secret_profile.yaml", "")
+		loadFunc := newYAMLLoaderWithProfile("testdata/secret_profile.yaml", "")
 		envVars := gt.R1(loadFunc(context.Background())).NoError(t)
 
 		varMap := make(map[string]*model.EnvVar)

--- a/pkg/model/errors.go
+++ b/pkg/model/errors.go
@@ -31,13 +31,17 @@ func (f ConfigFormat) String() string {
 type ConfigFileReason int
 
 const (
-	// ReasonNotReadable indicates the file could not be opened or read.
+	// ReasonNotReadable indicates the file could not be opened or read
+	// (e.g. permission denied).
 	ReasonNotReadable ConfigFileReason = iota
 	// ReasonParseError indicates a syntactic parse failure.
 	ReasonParseError
 	// ReasonInvalidSchema indicates a semantically invalid configuration
 	// (unknown attribute, mutually exclusive fields, duplicate names, ...).
 	ReasonInvalidSchema
+	// ReasonNotFound indicates an explicitly requested file does not exist.
+	// Distinct from ReasonNotReadable so the user sees a different message.
+	ReasonNotFound
 )
 
 func (r ConfigFileReason) String() string {
@@ -48,6 +52,8 @@ func (r ConfigFileReason) String() string {
 		return "parse error"
 	case ReasonInvalidSchema:
 		return "invalid schema"
+	case ReasonNotFound:
+		return "not found"
 	default:
 		return "unknown"
 	}
@@ -73,6 +79,8 @@ func (e *ConfigFileError) Error() string {
 		b.WriteString("cannot parse ")
 	case ReasonInvalidSchema:
 		b.WriteString("invalid ")
+	case ReasonNotFound:
+		b.WriteString("missing ")
 	default:
 		b.WriteString("error in ")
 	}
@@ -326,6 +334,48 @@ func (e *CommandLaunchError) ExitCode() int {
 	default:
 		return 1
 	}
+}
+
+// ProfileNotFoundError indicates the user-supplied profile name was not
+// defined in any of the loaded configuration files. The user explicitly asked
+// for a profile, so silently falling back to the default would mask the bug.
+type ProfileNotFoundError struct {
+	Profile string
+	// Available is the sorted, deduplicated list of profile names that were
+	// found across every scanned configuration file. May be empty.
+	Available []string
+	// Paths is the list of configuration files that were scanned. May be empty
+	// when no configuration file was discovered at all.
+	Paths []string
+}
+
+func (e *ProfileNotFoundError) Error() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "profile %q not found", e.Profile)
+	if len(e.Available) > 0 {
+		fmt.Fprintf(&b, " (available: %s)", strings.Join(e.Available, ", "))
+	} else if len(e.Paths) == 0 {
+		b.WriteString(" (no configuration file was loaded)")
+	} else {
+		b.WriteString(" (no profiles defined in any loaded configuration)")
+	}
+	return b.String()
+}
+
+// InvalidLogLevelError indicates the user-supplied --log-level value was not
+// one of the recognized log levels.
+type InvalidLogLevelError struct {
+	Value string
+	// Allowed is the list of accepted log level names.
+	Allowed []string
+}
+
+func (e *InvalidLogLevelError) Error() string {
+	if len(e.Allowed) == 0 {
+		return fmt.Sprintf("invalid log level %q", e.Value)
+	}
+	return fmt.Sprintf("invalid log level %q (expected one of: %s)",
+		e.Value, strings.Join(e.Allowed, ", "))
 }
 
 // TruncateStderr returns the trailing portion of s, never exceeding limit

--- a/pkg/model/errors_test.go
+++ b/pkg/model/errors_test.go
@@ -32,6 +32,77 @@ func TestConfigFileError(t *testing.T) {
 	})
 }
 
+func TestConfigFileError_NotFound(t *testing.T) {
+	t.Run("reports missing file with path", func(t *testing.T) {
+		err := &model.ConfigFileError{
+			Path:   "missing.yaml",
+			Format: model.FormatYAML,
+			Reason: model.ReasonNotFound,
+		}
+		gt.S(t, err.Error()).
+			Contains("missing").
+			Contains("yaml").
+			Contains("missing.yaml")
+	})
+
+	t.Run("reason String", func(t *testing.T) {
+		gt.Equal(t, model.ReasonNotFound.String(), "not found")
+	})
+}
+
+func TestProfileNotFoundError(t *testing.T) {
+	t.Run("with available profiles", func(t *testing.T) {
+		err := &model.ProfileNotFoundError{
+			Profile:   "prod",
+			Available: []string{"dev", "staging"},
+			Paths:     []string{".env.yaml"},
+		}
+		gt.S(t, err.Error()).
+			Contains(`"prod"`).
+			Contains("not found").
+			Contains("dev, staging")
+	})
+
+	t.Run("with no profiles defined anywhere", func(t *testing.T) {
+		err := &model.ProfileNotFoundError{
+			Profile: "prod",
+			Paths:   []string{".env.yaml"},
+		}
+		gt.S(t, err.Error()).
+			Contains(`"prod"`).
+			Contains("no profiles defined")
+	})
+
+	t.Run("with no configuration file loaded", func(t *testing.T) {
+		err := &model.ProfileNotFoundError{Profile: "prod"}
+		gt.S(t, err.Error()).
+			Contains(`"prod"`).
+			Contains("no configuration file")
+	})
+}
+
+func TestInvalidLogLevelError(t *testing.T) {
+	t.Run("includes allowed list", func(t *testing.T) {
+		err := &model.InvalidLogLevelError{
+			Value:   "foo",
+			Allowed: []string{"debug", "info", "warn", "error"},
+		}
+		gt.S(t, err.Error()).
+			Contains(`"foo"`).
+			Contains("debug").
+			Contains("info").
+			Contains("warn").
+			Contains("error")
+	})
+
+	t.Run("without allowed list", func(t *testing.T) {
+		err := &model.InvalidLogLevelError{Value: "foo"}
+		gt.S(t, err.Error()).
+			Contains(`"foo"`).
+			Contains("invalid log level")
+	})
+}
+
 func TestVariableError(t *testing.T) {
 	t.Run("carries key in message", func(t *testing.T) {
 		err := &model.VariableError{


### PR DESCRIPTION
## Summary

Silently swallowing explicit CLI input was hiding real misconfiguration. `zenv` now fails fast when an explicit flag value cannot be honored:

- **`-e <path>` / `-c <path>`** — a missing file is now reported via `ConfigFileError{Reason: ReasonNotFound}` instead of being skipped.
- **`-p <profile>`** — an unknown profile name is rejected up-front with `ProfileNotFoundError`, which includes the list of profiles that *are* defined and the paths that were searched.
- **`-l <level>`** — `ParseLogLevel` now returns `(slog.Level, error)`; unknown values (including the empty string) produce `InvalidLogLevelError` with the accepted level names attached.

Default-discovery behavior is unchanged: when `-e` / `-c` are omitted, the absence of `.env`, `.env.yaml`, `.env.yml`, and `.env.hcl` is still tolerated. The new strictness only kicks in for values the user explicitly supplied.

Internally:

- Loader constructors gained a `mustExist bool` parameter so the CLI layer can encode "explicit vs. default" at the call site.
- A new helper `loader.CollectProfileNames` aggregates the profile-name set across every YAML/HCL file we are about to load, and the CLI runs a preflight check before any loader is executed.
- `os.IsNotExist` was replaced with `errors.Is(err, fs.ErrNotExist)` for consistency.
- `pkg/cli/errfmt.go` got source / hint branches for the two new error types.
- `docs/migration.md` documents the behavior change.

## Test plan

- [x] `go test ./...` passes for every package
- [x] `go vet ./...` and `go fmt ./...` are clean
- [x] New tests cover: missing `-e`/`-c` files (dotenv / YAML / HCL), unknown `-p`, invalid `-l`, the `CollectProfileNames` helper, and the new error types' rendering through `FormatError`
- [x] Existing default-discovery scenarios (no flags in an empty directory) verified to still succeed