### PR TITLE
ci: add cicd-sensor to Linux CI jobs

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -11,6 +11,7 @@ jobs:
     env:
       GO111MODULE: on
     steps:
+      - uses: cicd-sensor/cicd-sensor-action@6ee257338e68af2b279b321b3346fe5f385aa498 # v0.0.29
       - name: Checkout Source
         uses: actions/checkout@v2
       - name: Run Gosec Security Scanner

--- a/.github/workflows/reelase.yml
+++ b/.github/workflows/reelase.yml
@@ -17,6 +17,7 @@ jobs:
     env:
       goos: linux
     steps:
+      - uses: cicd-sensor/cicd-sensor-action@6ee257338e68af2b279b321b3346fe5f385aa498 # v0.0.29
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: cicd-sensor/cicd-sensor-action@6ee257338e68af2b279b321b3346fe5f385aa498 # v0.0.29
       - name: Checkout upstream repo
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: cicd-sensor/cicd-sensor-action@6ee257338e68af2b279b321b3346fe5f385aa498 # v0.0.29
       - name: Checkout upstream repo
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- Add [cicd-sensor](https://github.com/cicd-sensor/cicd-sensor) (eBPF-based runtime security sensor for CI/CD) as the first step in all Linux CI jobs: `test.yml`, `gosec.yml`, `trivy.yml`, and the `releases-linux` job in `reelase.yml`.
- Pinned to commit SHA `6ee257338e68af2b279b321b3346fe5f385aa498` (v0.0.29), as shown in the upstream Quick Start.
- The `releases-macos` job is intentionally excluded — cicd-sensor relies on Linux eBPF and does not run on macOS.

## Notes
- Upstream is marked **pre-release / active development**. Worth keeping an eye on the version pin and reviewing reports for false positives.
- The action runs as the first step so it can observe subsequent steps' process activity.
- No additional `permissions:` were added; if cicd-sensor needs extra scopes for attestations or summaries in the future, we can revisit per-workflow.

## Test plan
- [ ] Confirm `test.yml` succeeds with cicd-sensor as the first step
- [ ] Confirm `gosec.yml` succeeds and SARIF upload still works
- [ ] Confirm `trivy.yml` succeeds and SARIF upload still works
- [ ] On the next tag push, confirm `releases-linux` matrix (amd64, arm64) still builds and uploads artifacts; `releases-macos` is unchanged
- [ ] Check the cicd-sensor job summary on a sample run for any unexpected findings