### PR TITLE
feat(loader): make HCL parse errors actionable

### DIFF
--- a/pkg/cli/errfmt.go
+++ b/pkg/cli/errfmt.go
@@ -262,7 +262,15 @@ func describeNode(err error, w *errWriter, isFirstCause bool) (string, bool, err
 		// line the path, so print the detail directly instead of cfe.Error(),
 		// which would restate "cannot parse <fmt> file <path>:" before it.
 		if cfe.Reason == model.ReasonParseError && cfe.Detail != "" {
-			return label + cfe.Detail, true, cfe.Cause
+			// writeLine only indents the first line, so the source snippet and
+			// caret would otherwise print flush-left. Indent continuation lines
+			// to keep the whole diagnostic block aligned under the cause label.
+			indent := "  "
+			if !isFirstCause {
+				indent = "    "
+			}
+			detail := strings.ReplaceAll(cfe.Detail, "\n", "\n"+indent)
+			return label + detail, true, cfe.Cause
 		}
 		line := label + cfe.Error()
 		return line, true, cfe.Cause

--- a/pkg/cli/errfmt.go
+++ b/pkg/cli/errfmt.go
@@ -257,6 +257,13 @@ func describeNode(err error, w *errWriter, isFirstCause bool) (string, bool, err
 	var cfe *model.ConfigFileError
 	if errors.As(err, &cfe) && cfe == err {
 		label := w.writeCyan(causeLabel(isFirstCause))
+		// A parse error carries a multi-line diagnostic (location + source
+		// snippet + caret). The header already names the format and the Source
+		// line the path, so print the detail directly instead of cfe.Error(),
+		// which would restate "cannot parse <fmt> file <path>:" before it.
+		if cfe.Reason == model.ReasonParseError && cfe.Detail != "" {
+			return label + cfe.Detail, true, cfe.Cause
+		}
 		line := label + cfe.Error()
 		return line, true, cfe.Cause
 	}

--- a/pkg/loader/hcl_loader.go
+++ b/pkg/loader/hcl_loader.go
@@ -181,8 +181,10 @@ func renderHCLDiagnostics(diags hcl.Diagnostics, src []byte) string {
 
 	var b strings.Builder
 	for i, d := range diags {
+		// Separate diagnostics with a blank line so a multi-diagnostic report
+		// does not read as one dense block.
 		if i > 0 {
-			b.WriteString("\n")
+			b.WriteString("\n\n")
 		}
 
 		if d.Subject != nil {
@@ -196,9 +198,13 @@ func renderHCLDiagnostics(diags hcl.Diagnostics, src []byte) string {
 			b.WriteString(snippet)
 		}
 
+		// HCL's remediation prose is usually a single line, but indent every
+		// line so a multi-line detail stays aligned under its diagnostic.
 		if d.Detail != "" {
-			b.WriteString("\n    ")
-			b.WriteString(d.Detail)
+			for line := range strings.SplitSeq(d.Detail, "\n") {
+				b.WriteString("\n    ")
+				b.WriteString(line)
+			}
 		}
 	}
 	return b.String()
@@ -212,7 +218,11 @@ func hclSnippet(srcLines []string, rng *hcl.Range) string {
 	if rng == nil || rng.Start.Line < 1 || rng.Start.Line > len(srcLines) {
 		return ""
 	}
-	line := strings.ReplaceAll(srcLines[rng.Start.Line-1], "\t", " ")
+	// Strip a trailing CR so CRLF-terminated source lines do not emit a stray
+	// carriage return that scrambles the rendered snippet, then expand tabs to
+	// a single space so the caret column stays aligned with the text.
+	line := strings.TrimSuffix(srcLines[rng.Start.Line-1], "\r")
+	line = strings.ReplaceAll(line, "\t", " ")
 
 	caretCol := max(rng.Start.Column, 1)
 	caretLen := 1

--- a/pkg/loader/hcl_loader.go
+++ b/pkg/loader/hcl_loader.go
@@ -7,7 +7,9 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclparse"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/m-mizutani/ctxlog"
@@ -130,7 +132,11 @@ func loadHCLFile(ctx context.Context, path string, mustExist bool) (model.YAMLCo
 			Path:   path,
 			Format: model.FormatHCL,
 			Reason: model.ReasonParseError,
-			Detail: diags.Error(),
+			// diags.Error() collapses multiple diagnostics to "first, and N
+			// other(s)" and never shows the offending source line, so render
+			// each diagnostic with its location, a source snippet and a caret
+			// instead — that is what makes a parse failure actionable.
+			Detail: renderHCLDiagnostics(diags, data),
 		}
 	}
 
@@ -162,6 +168,66 @@ func loadHCLFile(ctx context.Context, path string, mustExist bool) (model.YAMLCo
 		}
 	}
 	return cfg, nil
+}
+
+// renderHCLDiagnostics turns parse diagnostics into a multi-line, human-readable
+// report. Each diagnostic shows its location, the offending source line and a
+// caret pointing at the column, followed by HCL's own remediation prose. We hand-
+// roll this instead of using hcl.NewDiagnosticTextWriter so the output nests
+// cleanly under the CLI error formatter (no duplicated "Error:" headers or file
+// paths, both of which the formatter already prints).
+func renderHCLDiagnostics(diags hcl.Diagnostics, src []byte) string {
+	srcLines := strings.Split(string(src), "\n")
+
+	var b strings.Builder
+	for i, d := range diags {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+
+		if d.Subject != nil {
+			fmt.Fprintf(&b, "line %d, column %d: %s", d.Subject.Start.Line, d.Subject.Start.Column, d.Summary)
+		} else {
+			b.WriteString(d.Summary)
+		}
+
+		if snippet := hclSnippet(srcLines, d.Subject); snippet != "" {
+			b.WriteString("\n")
+			b.WriteString(snippet)
+		}
+
+		if d.Detail != "" {
+			b.WriteString("\n    ")
+			b.WriteString(d.Detail)
+		}
+	}
+	return b.String()
+}
+
+// hclSnippet renders the source line referenced by rng plus a caret line
+// underneath it. Tabs are expanded to a single space so the caret column stays
+// aligned with the rendered text. Returns "" when the range is missing or
+// points outside the available source.
+func hclSnippet(srcLines []string, rng *hcl.Range) string {
+	if rng == nil || rng.Start.Line < 1 || rng.Start.Line > len(srcLines) {
+		return ""
+	}
+	line := strings.ReplaceAll(srcLines[rng.Start.Line-1], "\t", " ")
+
+	caretCol := max(rng.Start.Column, 1)
+	caretLen := 1
+	// A single-line range tells us how many columns the offending token spans.
+	if rng.End.Line == rng.Start.Line && rng.End.Column > rng.Start.Column {
+		caretLen = rng.End.Column - rng.Start.Column
+	}
+
+	var b strings.Builder
+	b.WriteString("    ")
+	b.WriteString(line)
+	b.WriteString("\n    ")
+	b.WriteString(strings.Repeat(" ", caretCol-1))
+	b.WriteString(strings.Repeat("^", caretLen))
+	return b.String()
 }
 
 // parseHCLBody converts the top-level body of an HCL file into a YAMLConfig.

--- a/pkg/loader/hcl_loader_test.go
+++ b/pkg/loader/hcl_loader_test.go
@@ -118,6 +118,36 @@ func TestHCLLoaderSyntaxError(t *testing.T) {
 	loadFunc := newHCLLoader(path)
 	_, err := loadFunc(context.Background())
 	gt.Error(t, err)
+
+	var cfgErr *model.ConfigFileError
+	gt.True(t, errors.As(err, &cfgErr))
+	gt.Equal(t, cfgErr.Reason, model.ReasonParseError)
+}
+
+// A parse failure must point the user at the offending location with a source
+// snippet and a caret, not just a one-line summary.
+func TestHCLLoaderSyntaxErrorDetail(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "broken.hcl")
+	// An unterminated string spanning two physical lines: HCL reports an
+	// "Invalid multi-line string" with remediation prose.
+	gt.NoError(t, os.WriteFile(path, []byte("FOO = \"bar\nBAZ = \"qux\"\n"), 0600))
+
+	loadFunc := newHCLLoader(path)
+	_, err := loadFunc(context.Background())
+	gt.Error(t, err)
+
+	var cfgErr *model.ConfigFileError
+	gt.True(t, errors.As(err, &cfgErr))
+	gt.Equal(t, cfgErr.Reason, model.ReasonParseError)
+
+	// Location, the offending source line, the caret and HCL's remediation
+	// prose must all be present.
+	gt.S(t, cfgErr.Detail).
+		Contains("line 1").
+		Contains(`FOO = "bar`).
+		Contains("^").
+		Contains("multi-line")
 }
 
 func TestHCLLoaderDuplicateName(t *testing.T) {


### PR DESCRIPTION
## Why

When an `.env.hcl` file failed to parse, the error was too terse to act on — it told the user *that* parsing failed but not *where* or *why*. Reported symptom:

```
Error: failed to load environment variables: failed to parse HCL file
```

`diags.Error()` also collapses multiple diagnostics into "first, and N other(s)" and never surfaces the offending source line, so even the current output hid the most useful information.

## What

- Render HCL parse diagnostics with location, the offending source line, a caret pointing at the column, and HCL's own remediation prose, instead of the collapsed `diags.Error()` one-liner.
- The renderer is hand-rolled (rather than `hcl.NewDiagnosticTextWriter`) so the output nests cleanly under the CLI error formatter without duplicating the `Error:` header or the file path.
- The CLI formatter now prints the rich detail directly for parse errors, since the format name (header) and path (`Source:` line) are already shown — avoiding `cannot parse hcl file <path>:` restatement.

Example output:

```
Error: Cannot parse hcl config file
  Source: /path/to/.env.hcl
  Cause:  line 1, column 7: Invalid multi-line string
    FOO = "bar
          ^
    Quoted strings may not be split over multiple lines. ...

  Hint:  fix the syntax error reported above and retry
```

## Tests

- `TestHCLLoaderSyntaxError` now asserts the typed `ConfigFileError` / `ReasonParseError`.
- New `TestHCLLoaderSyntaxErrorDetail` verifies the detail contains the location, source line, caret, and remediation text.
- `go test ./...`, `go vet`, and `gosec` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)